### PR TITLE
fix: Removed legacy source generator project from docker build.

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -58,7 +58,6 @@ WORKDIR /src
 COPY ["lucia.AgentHost/lucia.AgentHost.csproj", "lucia.AgentHost/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
-COPY ["lucia.HomeAssistant.SourceGenerator/lucia.HomeAssistant.SourceGenerator.csproj", "lucia.HomeAssistant.SourceGenerator/"]
 COPY ["lucia.ServiceDefaults/lucia.ServiceDefaults.csproj", "lucia.ServiceDefaults/"]
 
 # Restore dependencies

--- a/infra/docker/Dockerfile.a2ahost
+++ b/infra/docker/Dockerfile.a2ahost
@@ -31,7 +31,6 @@ WORKDIR /src
 COPY ["lucia.A2AHost/lucia.A2AHost.csproj", "lucia.A2AHost/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
-COPY ["lucia.HomeAssistant.SourceGenerator/lucia.HomeAssistant.SourceGenerator.csproj", "lucia.HomeAssistant.SourceGenerator/"]
 COPY ["lucia.ServiceDefaults/lucia.ServiceDefaults.csproj", "lucia.ServiceDefaults/"]
 
 RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj"

--- a/infra/docker/Dockerfile.music-agent
+++ b/infra/docker/Dockerfile.music-agent
@@ -20,7 +20,6 @@ WORKDIR /src
 COPY ["lucia.MusicAgent/lucia.MusicAgent.csproj", "lucia.MusicAgent/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
-COPY ["lucia.HomeAssistant.SourceGenerator/lucia.HomeAssistant.SourceGenerator.csproj", "lucia.HomeAssistant.SourceGenerator/"]
 
 RUN dotnet restore "./lucia.MusicAgent/lucia.MusicAgent.csproj"
 

--- a/infra/docker/Dockerfile.timer-agent
+++ b/infra/docker/Dockerfile.timer-agent
@@ -20,7 +20,6 @@ WORKDIR /src
 COPY ["lucia.TimerAgent/lucia.TimerAgent.csproj", "lucia.TimerAgent/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
-COPY ["lucia.HomeAssistant.SourceGenerator/lucia.HomeAssistant.SourceGenerator.csproj", "lucia.HomeAssistant.SourceGenerator/"]
 
 RUN dotnet restore "./lucia.TimerAgent/lucia.TimerAgent.csproj"
 


### PR DESCRIPTION
This pull request updates several Dockerfiles to remove the copying of the `lucia.HomeAssistant.SourceGenerator` project during the build process. This change helps streamline the build context for multiple service containers and avoids including unnecessary source generator files.

Build context cleanup:

* Removed the `COPY` instruction for `lucia.HomeAssistant.SourceGenerator/lucia.HomeAssistant.SourceGenerator.csproj` from the following Dockerfiles: `Dockerfile`, `Dockerfile.a2ahost`, `Dockerfile.music-agent`, and `Dockerfile.timer-agent`. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848L61) [[2]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fL34) [[3]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4L23) [[4]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0L23)