### PR TITLE
Bug fix docker build

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -54,6 +54,11 @@ ARG BUILD_TARGET_FRAMEWORK=net10.0
 # Set working directory
 WORKDIR /src
 
+# Copy MSBuild infrastructure files required before restore
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["NuGet.Config", "."]
+
 # Copy project files (maintaining directory structure)
 COPY ["lucia.AgentHost/lucia.AgentHost.csproj", "lucia.AgentHost/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]

--- a/infra/docker/Dockerfile.a2ahost
+++ b/infra/docker/Dockerfile.a2ahost
@@ -27,6 +27,11 @@ ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
+# Copy MSBuild infrastructure files required before restore
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["NuGet.Config", "."]
+
 # Copy project files for restore layer caching (A2AHost + dependencies only)
 COPY ["lucia.A2AHost/lucia.A2AHost.csproj", "lucia.A2AHost/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]

--- a/infra/docker/Dockerfile.music-agent
+++ b/infra/docker/Dockerfile.music-agent
@@ -16,6 +16,11 @@ ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
+# Copy MSBuild infrastructure files required before restore
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["NuGet.Config", "."]
+
 # Copy project files for restore layer caching
 COPY ["lucia.MusicAgent/lucia.MusicAgent.csproj", "lucia.MusicAgent/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]

--- a/infra/docker/Dockerfile.timer-agent
+++ b/infra/docker/Dockerfile.timer-agent
@@ -16,6 +16,11 @@ ARG BUILD_CONFIGURATION=Release
 
 WORKDIR /src
 
+# Copy MSBuild infrastructure files required before restore
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["NuGet.Config", "."]
+
 # Copy project files for restore layer caching
 COPY ["lucia.TimerAgent/lucia.TimerAgent.csproj", "lucia.TimerAgent/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]

--- a/lucia.A2AHost/Dockerfile
+++ b/lucia.A2AHost/Dockerfile
@@ -12,6 +12,9 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["NuGet.Config", "."]
 COPY ["lucia.A2AHost/lucia.A2AHost.csproj", "lucia.A2AHost/"]
 RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj"
 COPY . .

--- a/lucia.AgentHost/Dockerfile
+++ b/lucia.AgentHost/Dockerfile
@@ -12,6 +12,8 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
 COPY ["NuGet.Config", "."]
 COPY ["lucia.AgentHost/lucia.AgentHost.csproj", "lucia.AgentHost/"]
 RUN dotnet restore "./lucia.AgentHost/lucia.AgentHost.csproj"


### PR DESCRIPTION
This pull request updates the Docker build process for several .NET projects to ensure that required MSBuild infrastructure files are copied before restoring dependencies. This change improves build reliability and caching by making sure that the build environment has all necessary configuration files at the correct stage. Additionally, the Dockerfiles no longer copy the `lucia.HomeAssistant.SourceGenerator` project file, likely because it is no longer needed for these builds.

**Docker build improvements:**

* Added steps to copy `Directory.Build.props`, `Directory.Packages.props`, and `NuGet.Config` before restoring dependencies in the following Dockerfiles: `infra/docker/Dockerfile`, `infra/docker/Dockerfile.a2ahost`, `infra/docker/Dockerfile.music-agent`, `infra/docker/Dockerfile.timer-agent`, `lucia.A2AHost/Dockerfile`, and `lucia.AgentHost/Dockerfile`. This ensures all MSBuild infrastructure files are present for consistent and reliable restores. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848R57-L61) [[2]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fR30-L34) [[3]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4R19-L23) [[4]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0R19-L23) [[5]](diffhunk://#diff-c30380c3f5421c39c6a2957b78f1304b6048dba1fe9849434bb6fab4f081ca08R15-R17) [[6]](diffhunk://#diff-403c8e552b7ac00bbe282b5fcd31cbda999c3f48e119a0f437913ce4907a0b37R15-R16)

* Removed the `COPY` command for `lucia.HomeAssistant.SourceGenerator/lucia.HomeAssistant.SourceGenerator.csproj` from Dockerfiles where it was previously included, reducing unnecessary files in the build context and streamlining the build process. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848R57-L61) [[2]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fR30-L34) [[3]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4R19-L23) [[4]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0R19-L23)