### PR TITLE
fix(docker): copy MSBuild infrastructure files before dotnet restore

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -57,9 +57,8 @@ WORKDIR /src
 # Copy MSBuild infrastructure files required before restore
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
-COPY ["NuGet.Config", "."]
 
-# Copy project files (maintaining directory structure)
+# Copy project files(maintaining directory structure)
 COPY ["lucia.AgentHost/lucia.AgentHost.csproj", "lucia.AgentHost/"]
 COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]

--- a/infra/docker/Dockerfile.a2ahost
+++ b/infra/docker/Dockerfile.a2ahost
@@ -30,7 +30,6 @@ WORKDIR /src
 # Copy MSBuild infrastructure files required before restore
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
-COPY ["NuGet.Config", "."]
 
 # Copy project files for restore layer caching (A2AHost + dependencies only)
 COPY ["lucia.A2AHost/lucia.A2AHost.csproj", "lucia.A2AHost/"]

--- a/infra/docker/Dockerfile.music-agent
+++ b/infra/docker/Dockerfile.music-agent
@@ -19,7 +19,6 @@ WORKDIR /src
 # Copy MSBuild infrastructure files required before restore
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
-COPY ["NuGet.Config", "."]
 
 # Copy project files for restore layer caching
 COPY ["lucia.MusicAgent/lucia.MusicAgent.csproj", "lucia.MusicAgent/"]

--- a/infra/docker/Dockerfile.timer-agent
+++ b/infra/docker/Dockerfile.timer-agent
@@ -19,7 +19,6 @@ WORKDIR /src
 # Copy MSBuild infrastructure files required before restore
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
-COPY ["NuGet.Config", "."]
 
 # Copy project files for restore layer caching
 COPY ["lucia.TimerAgent/lucia.TimerAgent.csproj", "lucia.TimerAgent/"]

--- a/lucia.A2AHost/Dockerfile
+++ b/lucia.A2AHost/Dockerfile
@@ -14,7 +14,6 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
-COPY ["NuGet.Config", "."]
 COPY ["lucia.A2AHost/lucia.A2AHost.csproj", "lucia.A2AHost/"]
 RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj"
 COPY . .

--- a/lucia.AgentHost/Dockerfile
+++ b/lucia.AgentHost/Dockerfile
@@ -14,7 +14,6 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
-COPY ["NuGet.Config", "."]
 COPY ["lucia.AgentHost/lucia.AgentHost.csproj", "lucia.AgentHost/"]
 RUN dotnet restore "./lucia.AgentHost/lucia.AgentHost.csproj"
 COPY . .


### PR DESCRIPTION
This pull request removes the copying of the `NuGet.Config` file in several Dockerfiles across the project. This change affects the build process for multiple services by no longer including `NuGet.Config` in the container build context. This likely assumes that the default NuGet configuration is sufficient, or that configuration is managed elsewhere.

Build process simplification:

* Removed the `COPY ["NuGet.Config", "."]` line from the following Dockerfiles to streamline the build context:
  * `infra/docker/Dockerfile`
  * `infra/docker/Dockerfile.a2ahost`
  * `infra/docker/Dockerfile.music-agent`
  * `infra/docker/Dockerfile.timer-agent`
  * `lucia.A2AHost/Dockerfile`
  * `lucia.AgentHost/Dockerfile`