### PR TITLE
fix(docker): resilient Copilot CLI download with optional inclusion

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -2,14 +2,46 @@
 # Purpose: Create optimized production image for lucia.AgentHost service
 # 
 # Stages:
+#   - copilot-cli: Download Copilot CLI binary (optional, resilient)
 #   - node-build: Build the React SPA dashboard with Node.js
 #   - base: ASP.NET 10.0 runtime base image with non-root user
 #   - build: Build the application with .NET SDK
 #   - publish: Publish optimized release build
 #   - final: Production image with health checks and security hardening
+#
+# Build args:
+#   INCLUDE_COPILOT_CLI - Include Copilot CLI binary (default: true)
+#   COPILOT_CLI_VERSION - Copilot CLI version to download (default: 0.0.411)
+#   BUILD_CONFIGURATION - Debug or Release (default: Release)
+#   BUILD_TARGET_FRAMEWORK - Target framework version (default: net10.0)
 
 # ============================================================================
-# Stage 0: Node.js Build Stage (React SPA Dashboard)
+# Stage 0a: Download Copilot CLI binary (resilient, downloaded once)
+# ============================================================================
+FROM alpine:3.21 AS copilot-cli
+
+ARG INCLUDE_COPILOT_CLI=true
+ARG COPILOT_CLI_VERSION=0.0.411
+ARG TARGETARCH
+
+RUN if [ "$INCLUDE_COPILOT_CLI" = "true" ]; then \
+      apk add --no-cache curl && \
+      PLATFORM=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      RID=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      mkdir -p /copilot-out/runtimes/${RID}/native && \
+      echo "Downloading Copilot CLI ${COPILOT_CLI_VERSION} for ${PLATFORM}..." && \
+      curl -fSL --retry 5 --retry-delay 10 --retry-max-time 300 \
+        "https://registry.npmjs.org/@github/copilot-${PLATFORM}/-/copilot-${PLATFORM}-${COPILOT_CLI_VERSION}.tgz" \
+        -o /tmp/copilot.tgz && \
+      tar -xzf /tmp/copilot.tgz --strip-components=1 -C /copilot-out/runtimes/${RID}/native && \
+      chmod +x /copilot-out/runtimes/${RID}/native/copilot && \
+      rm /tmp/copilot.tgz; \
+    else \
+      mkdir -p /copilot-out; \
+    fi
+
+# ============================================================================
+# Stage 0b: Node.js Build Stage (React SPA Dashboard)
 # ============================================================================
 FROM node:22-alpine AS node-build
 
@@ -64,11 +96,12 @@ COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
 COPY ["lucia.ServiceDefaults/lucia.ServiceDefaults.csproj", "lucia.ServiceDefaults/"]
 
-# Restore dependencies
+# Restore dependencies (skip Copilot CLI download — handled in copilot-cli stage)
 # This layer is cached unless .csproj files change
 RUN dotnet restore "./lucia.AgentHost/lucia.AgentHost.csproj" \
     --runtime linux-x64 \
-    /p:PublishReadyToRun=true
+    /p:PublishReadyToRun=true \
+    /p:CopilotSkipCliDownload=true
 
 # Copy entire source tree
 COPY . .
@@ -81,7 +114,8 @@ RUN dotnet build "./lucia.AgentHost/lucia.AgentHost.csproj" \
     -o /app/build \
     --runtime linux-x64 \
     --framework $BUILD_TARGET_FRAMEWORK \
-    --no-restore
+    --no-restore \
+    /p:CopilotSkipCliDownload=true
 
 # ============================================================================
 # Stage 3: Publish Stage
@@ -102,7 +136,8 @@ RUN dotnet publish "./lucia.AgentHost/lucia.AgentHost.csproj" \
     --runtime linux-x64 \
     /p:UseAppHost=false \
     /p:PublishTrimmed=false \
-    /p:PublishReadyToRun=true
+    /p:PublishReadyToRun=true \
+    /p:CopilotSkipCliDownload=true
 
 # ============================================================================
 # Stage 4: Final Production Image
@@ -123,6 +158,9 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 # Copy published application from publish stage
 COPY --from=publish --chown=appuser:appuser /app/publish .
 
+# Copy Copilot CLI binary (if INCLUDE_COPILOT_CLI=true)
+COPY --from=copilot-cli --chown=appuser:appuser /copilot-out/ ./
+
 # Copy built SPA dashboard into wwwroot for static file serving
 COPY --from=node-build --chown=appuser:appuser /app/dist ./wwwroot/
 
@@ -141,13 +179,15 @@ ENTRYPOINT ["dotnet", "lucia.AgentHost.dll"]
 # Build arguments documentation:
 # BUILD_CONFIGURATION - "Debug" or "Release" (default: Release)
 # BUILD_TARGET_FRAMEWORK - Target framework version (default: net10.0)
+# INCLUDE_COPILOT_CLI - Include Copilot CLI binary (default: true, set false for smaller image)
+# COPILOT_CLI_VERSION - Copilot CLI version (default: 0.0.411)
 #
 # Usage examples:
 #   # Standard production build
 #   docker build -t lucia:latest -f infra/docker/Dockerfile .
 #
+#   # Build without Copilot CLI (smaller image)
+#   docker build --build-arg INCLUDE_COPILOT_CLI=false -t lucia:latest -f infra/docker/Dockerfile .
+#
 #   # Debug build for troubleshooting
 #   docker build --build-arg BUILD_CONFIGURATION=Debug -t lucia:debug -f infra/docker/Dockerfile .
-#
-#   # Specific framework (if supporting multiple)
-#   docker build --build-arg BUILD_TARGET_FRAMEWORK=net10.0 -t lucia:net10 -f infra/docker/Dockerfile .

--- a/infra/docker/Dockerfile.a2ahost
+++ b/infra/docker/Dockerfile.a2ahost
@@ -5,6 +5,35 @@
 #
 # Build:
 #   docker build -f infra/docker/Dockerfile.a2ahost -t lucia-a2ahost:latest .
+#
+# Build args:
+#   INCLUDE_COPILOT_CLI - Include Copilot CLI binary (default: true)
+#   COPILOT_CLI_VERSION - Copilot CLI version to download (default: 0.0.411)
+
+# ============================================================================
+# Stage 0: Download Copilot CLI binary (resilient, downloaded once)
+# ============================================================================
+FROM alpine:3.21 AS copilot-cli
+
+ARG INCLUDE_COPILOT_CLI=true
+ARG COPILOT_CLI_VERSION=0.0.411
+ARG TARGETARCH
+
+RUN if [ "$INCLUDE_COPILOT_CLI" = "true" ]; then \
+      apk add --no-cache curl && \
+      PLATFORM=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      RID=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      mkdir -p /copilot-out/runtimes/${RID}/native && \
+      echo "Downloading Copilot CLI ${COPILOT_CLI_VERSION} for ${PLATFORM}..." && \
+      curl -fSL --retry 5 --retry-delay 10 --retry-max-time 300 \
+        "https://registry.npmjs.org/@github/copilot-${PLATFORM}/-/copilot-${PLATFORM}-${COPILOT_CLI_VERSION}.tgz" \
+        -o /tmp/copilot.tgz && \
+      tar -xzf /tmp/copilot.tgz --strip-components=1 -C /copilot-out/runtimes/${RID}/native && \
+      chmod +x /copilot-out/runtimes/${RID}/native/copilot && \
+      rm /tmp/copilot.tgz; \
+    else \
+      mkdir -p /copilot-out; \
+    fi
 
 # ============================================================================
 # Stage 1: Base Runtime Image
@@ -37,7 +66,8 @@ COPY ["lucia.Agents/lucia.Agents.csproj", "lucia.Agents/"]
 COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
 COPY ["lucia.ServiceDefaults/lucia.ServiceDefaults.csproj", "lucia.ServiceDefaults/"]
 
-RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj"
+RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj" \
+    /p:CopilotSkipCliDownload=true
 
 # Copy source tree and build
 COPY . .
@@ -45,7 +75,8 @@ COPY . .
 RUN dotnet publish "./lucia.A2AHost/lucia.A2AHost.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    /p:CopilotSkipCliDownload=true
 
 # ============================================================================
 # Stage 3: Final Production Image
@@ -64,6 +95,9 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 
 # Copy published A2AHost application
 COPY --from=build --chown=appuser:appuser /app/publish .
+
+# Copy Copilot CLI binary (if INCLUDE_COPILOT_CLI=true)
+COPY --from=copilot-cli --chown=appuser:appuser /copilot-out/ ./
 
 # Create plugins directory (agents will populate this)
 RUN mkdir -p /app/plugins && chown appuser:appuser /app/plugins

--- a/infra/docker/Dockerfile.music-agent
+++ b/infra/docker/Dockerfile.music-agent
@@ -4,6 +4,35 @@
 #
 # Build (from repo root):
 #   docker build -f infra/docker/Dockerfile.music-agent -t lucia-music-agent:latest .
+#
+# Build args:
+#   INCLUDE_COPILOT_CLI - Include Copilot CLI binary (default: true)
+#   COPILOT_CLI_VERSION - Copilot CLI version to download (default: 0.0.411)
+
+# ============================================================================
+# Stage 0: Download Copilot CLI binary (resilient, downloaded once)
+# ============================================================================
+FROM alpine:3.21 AS copilot-cli
+
+ARG INCLUDE_COPILOT_CLI=true
+ARG COPILOT_CLI_VERSION=0.0.411
+ARG TARGETARCH
+
+RUN if [ "$INCLUDE_COPILOT_CLI" = "true" ]; then \
+      apk add --no-cache curl && \
+      PLATFORM=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      RID=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      mkdir -p /copilot-out/runtimes/${RID}/native && \
+      echo "Downloading Copilot CLI ${COPILOT_CLI_VERSION} for ${PLATFORM}..." && \
+      curl -fSL --retry 5 --retry-delay 10 --retry-max-time 300 \
+        "https://registry.npmjs.org/@github/copilot-${PLATFORM}/-/copilot-${PLATFORM}-${COPILOT_CLI_VERSION}.tgz" \
+        -o /tmp/copilot.tgz && \
+      tar -xzf /tmp/copilot.tgz --strip-components=1 -C /copilot-out/runtimes/${RID}/native && \
+      chmod +x /copilot-out/runtimes/${RID}/native/copilot && \
+      rm /tmp/copilot.tgz; \
+    else \
+      mkdir -p /copilot-out; \
+    fi
 
 # ============================================================================
 # Stage 1: Runtime base
@@ -37,7 +66,9 @@ COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
 COPY ["lucia.ServiceDefaults/lucia.ServiceDefaults.csproj", "lucia.ServiceDefaults/"]
 
 RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj" \
- && dotnet restore "./lucia.MusicAgent/lucia.MusicAgent.csproj"
+    /p:CopilotSkipCliDownload=true \
+ && dotnet restore "./lucia.MusicAgent/lucia.MusicAgent.csproj" \
+    /p:CopilotSkipCliDownload=true
 
 # Copy source and publish both projects
 COPY . .
@@ -45,12 +76,14 @@ COPY . .
 RUN dotnet publish "./lucia.A2AHost/lucia.A2AHost.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/host-publish \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    /p:CopilotSkipCliDownload=true
 
 RUN dotnet publish "./lucia.MusicAgent/lucia.MusicAgent.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/plugin-publish \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    /p:CopilotSkipCliDownload=true
 
 # ============================================================================
 # Stage 3: Final production image
@@ -69,6 +102,9 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 
 # Copy A2AHost application
 COPY --from=build --chown=appuser:appuser /app/host-publish .
+
+# Copy Copilot CLI binary (if INCLUDE_COPILOT_CLI=true)
+COPY --from=copilot-cli --chown=appuser:appuser /copilot-out/ ./
 
 # Create plugins directory and copy plugin DLL
 RUN mkdir -p /app/plugins && chown appuser:appuser /app/plugins

--- a/infra/docker/Dockerfile.timer-agent
+++ b/infra/docker/Dockerfile.timer-agent
@@ -4,6 +4,35 @@
 #
 # Build (from repo root):
 #   docker build -f infra/docker/Dockerfile.timer-agent -t lucia-timer-agent:latest .
+#
+# Build args:
+#   INCLUDE_COPILOT_CLI - Include Copilot CLI binary (default: true)
+#   COPILOT_CLI_VERSION - Copilot CLI version to download (default: 0.0.411)
+
+# ============================================================================
+# Stage 0: Download Copilot CLI binary (resilient, downloaded once)
+# ============================================================================
+FROM alpine:3.21 AS copilot-cli
+
+ARG INCLUDE_COPILOT_CLI=true
+ARG COPILOT_CLI_VERSION=0.0.411
+ARG TARGETARCH
+
+RUN if [ "$INCLUDE_COPILOT_CLI" = "true" ]; then \
+      apk add --no-cache curl && \
+      PLATFORM=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      RID=$(case "$TARGETARCH" in amd64) echo "linux-x64";; arm64) echo "linux-arm64";; *) echo "linux-x64";; esac) && \
+      mkdir -p /copilot-out/runtimes/${RID}/native && \
+      echo "Downloading Copilot CLI ${COPILOT_CLI_VERSION} for ${PLATFORM}..." && \
+      curl -fSL --retry 5 --retry-delay 10 --retry-max-time 300 \
+        "https://registry.npmjs.org/@github/copilot-${PLATFORM}/-/copilot-${PLATFORM}-${COPILOT_CLI_VERSION}.tgz" \
+        -o /tmp/copilot.tgz && \
+      tar -xzf /tmp/copilot.tgz --strip-components=1 -C /copilot-out/runtimes/${RID}/native && \
+      chmod +x /copilot-out/runtimes/${RID}/native/copilot && \
+      rm /tmp/copilot.tgz; \
+    else \
+      mkdir -p /copilot-out; \
+    fi
 
 # ============================================================================
 # Stage 1: Runtime base
@@ -37,7 +66,9 @@ COPY ["lucia.HomeAssistant/lucia.HomeAssistant.csproj", "lucia.HomeAssistant/"]
 COPY ["lucia.ServiceDefaults/lucia.ServiceDefaults.csproj", "lucia.ServiceDefaults/"]
 
 RUN dotnet restore "./lucia.A2AHost/lucia.A2AHost.csproj" \
- && dotnet restore "./lucia.TimerAgent/lucia.TimerAgent.csproj"
+    /p:CopilotSkipCliDownload=true \
+ && dotnet restore "./lucia.TimerAgent/lucia.TimerAgent.csproj" \
+    /p:CopilotSkipCliDownload=true
 
 # Copy source and publish both projects
 COPY . .
@@ -45,12 +76,14 @@ COPY . .
 RUN dotnet publish "./lucia.A2AHost/lucia.A2AHost.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/host-publish \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    /p:CopilotSkipCliDownload=true
 
 RUN dotnet publish "./lucia.TimerAgent/lucia.TimerAgent.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/plugin-publish \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    /p:CopilotSkipCliDownload=true
 
 # ============================================================================
 # Stage 3: Final production image
@@ -69,6 +102,9 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 
 # Copy A2AHost application
 COPY --from=build --chown=appuser:appuser /app/host-publish .
+
+# Copy Copilot CLI binary (if INCLUDE_COPILOT_CLI=true)
+COPY --from=copilot-cli --chown=appuser:appuser /copilot-out/ ./
 
 # Create plugins directory and copy plugin DLL
 RUN mkdir -p /app/plugins && chown appuser:appuser /app/plugins


### PR DESCRIPTION
This pull request introduces a unified and resilient approach for including the Copilot CLI binary in all production Docker images for the lucia services. It adds a dedicated build stage for downloading the Copilot CLI, provides new build arguments for flexibility, and ensures that .NET builds skip redundant Copilot CLI downloads. These improvements make the images more consistent, customizable, and reduce unnecessary downloads during builds.

Copilot CLI integration and build optimization:

* Added a dedicated `copilot-cli` build stage to all Dockerfiles (`infra/docker/Dockerfile`, `infra/docker/Dockerfile.a2ahost`, `infra/docker/Dockerfile.music-agent`, `infra/docker/Dockerfile.timer-agent`) that downloads the Copilot CLI binary in a resilient manner, supporting multiple architectures and versioning. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848R5-R44) [[2]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fR8-R36) [[3]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4R7-R35) [[4]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0R7-R35)
* Introduced build arguments `INCLUDE_COPILOT_CLI` and `COPILOT_CLI_VERSION` to control whether the Copilot CLI is included and which version to download, allowing for smaller images or custom versions. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848R5-R44) [[2]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fR8-R36) [[3]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4R7-R35) [[4]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0R7-R35)
* Updated .NET restore, build, and publish steps to use `/p:CopilotSkipCliDownload=true`, preventing redundant Copilot CLI downloads during the build process and relying on the Docker build stage instead. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848L67-R104) [[2]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848L84-R118) [[3]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848L105-R140) [[4]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fL40-R79) [[5]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4L40-R86) [[6]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0L40-R86)

Image composition and documentation:

* Ensured the Copilot CLI binary is copied into the final production image only if enabled, using `COPY --from=copilot-cli ...` in all Dockerfiles. [[1]](diffhunk://#diff-c54ce94965e3a9ebb46a4b48c515a603c5d119dbf707a1a39e1881f9c4db5848R161-R163) [[2]](diffhunk://#diff-b5a0c649ce811c020b9cc747344367dc205ebe363b07df9f78683e61a125317fR99-R101) [[3]](diffhunk://#diff-534f3816ebe3b50f48265df48dd3938c1af8e8e40eb21a91e1c618073a72ecb4R106-R108) [[4]](diffhunk://#diff-8e692f8df2a237ac134515dab2417cd6117c296a31324bd223276f96583b24e0R106-R108)
* Improved build documentation and usage examples in Dockerfiles, explaining new build arguments and how to build images with or without the Copilot CLI.

These changes streamline Copilot CLI inclusion, improve build reliability, and offer greater flexibility for production deployments.