### PR TITLE
adding missing env values and updating middleware

### DIFF
--- a/infra/docker/.env.lucia.example
+++ b/infra/docker/.env.lucia.example
@@ -5,6 +5,8 @@
 # Then set HomeAssistant__AccessToken and optionally adjust URLs.
 #
 # Use with: docker compose -f docker-compose.yml -f docker-compose.lucia-sidecar.yml --env-file .env up -d
+# Preload: the sidecar compose adds env_file: .env to the lucia service, so all variables below
+# are loaded into the container. You must use BOTH compose files for preload to happen.
 #
 # Home Assistant runs on a different host (e.g. 192.168.1.198). Lucia runs on the
 # same machine as your Open Web UI stack and reaches Ollama via host.docker.internal.

--- a/infra/docker/docker-compose.lucia-sidecar.yml
+++ b/infra/docker/docker-compose.lucia-sidecar.yml
@@ -9,7 +9,8 @@
 #
 # This override adds:
 #   - extra_hosts so Lucia can reach host services (Ollama, SearXNG, ComfyUI, etc.)
-#   - env_file to load .env so ConnectionStrings__chat-model passes through correctly
+#   - env_file: .env — preloads ALL variables from .env into the lucia container (required for
+#     headless setup, HA, Ollama, METAMCP, etc.). Path is relative to this compose file's directory.
 #
 # MetaMCP connectivity: Lucia uses METAMCP_URL from .env. If 172.18.0.1 or host.docker.internal
 # fail, attach Lucia to Open Web UI network: uncomment the networks section below and set
@@ -21,6 +22,7 @@ services:
   lucia:
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    # Preload .env into container (all vars: DASHBOARD_API_KEY, HomeAssistant__*, ConnectionStrings__*, etc.)
     env_file:
       - .env
     environment:

--- a/lucia.AgentHost/Auth/OnboardingMiddleware.cs
+++ b/lucia.AgentHost/Auth/OnboardingMiddleware.cs
@@ -61,7 +61,8 @@ public sealed class OnboardingMiddleware
             return;
         }
 
-        // Determine setup state — fast path uses cached IConfiguration
+        // Determine setup state: IConfiguration (MongoDB-backed, 5s poll) and direct ConfigStore
+        // so headless seed is respected immediately without waiting for config poll
         var setupComplete = _setupCompleteLatch;
         if (!setupComplete)
         {
@@ -70,6 +71,13 @@ public sealed class OnboardingMiddleware
                 var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
                 setupComplete = string.Equals(
                     configuration["Auth:SetupComplete"], "true", StringComparison.OrdinalIgnoreCase);
+                if (!setupComplete)
+                {
+                    var configStore = context.RequestServices.GetRequiredService<ConfigStoreWriter>();
+                    var directValue = await configStore.GetAsync("Auth:SetupComplete", context.RequestAborted)
+                        .ConfigureAwait(false);
+                    setupComplete = string.Equals(directValue, "true", StringComparison.OrdinalIgnoreCase);
+                }
             }
             catch (Exception ex)
             {

--- a/lucia.AgentHost/Program.cs
+++ b/lucia.AgentHost/Program.cs
@@ -227,6 +227,17 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+// Headless seed: run before app accepts requests so env-based setup is in MongoDB
+// before OnboardingMiddleware or MongoConfigurationProvider are first read
+await using (var seedScope = app.Services.CreateAsyncScope())
+{
+    var apiKeyService = seedScope.ServiceProvider.GetRequiredService<IApiKeyService>();
+    var configStore = seedScope.ServiceProvider.GetRequiredService<ConfigStoreWriter>();
+    var config = seedScope.ServiceProvider.GetRequiredService<IConfiguration>();
+    var seedLogger = seedScope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Lucia.HeadlessSeed");
+    await apiKeyService.SeedSetupFromEnvAsync(configStore, config, seedLogger, CancellationToken.None).ConfigureAwait(false);
+}
+
 app.MapOpenApi()
     .CacheOutput();
 


### PR DESCRIPTION
## Description
Make Lucia fully headless-configurable from `.env` . On first startup, Lucia now seeds dashboard/HA API keys, Home Assistant connection details, and default Ollama model providers from environment variables, skipping the setup wizard when configured.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/formatting changes
- [x] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test updates
- [ ] 🔧 Build/CI changes

## Related Issues
Fixes #<!-- issue number, if applicable -->
Related to #<!-- issue number, if applicable -->

## Changes Made
- [x] Run `SeedSetupFromEnvAsync` during AgentHost startup so `.env` values (dashboard key, HA URL/token, Lucia HA key) are written to MongoDB before the app serves requests.
- [x] Update `OnboardingMiddleware` to consult the Mongo-backed config store for `Auth:SetupComplete`, ensuring env-based headless setup is respected without waiting for config polling.
- [x] Ensure default chat and embedding model providers are automatically seeded from `ConnectionStrings__chat-model`/`ConnectionStrings__embeddings` (Ollama) on first boot, unblocking agent initialization.
- [x] Clarify and document how `docker-compose.lucia-sidecar.yml` preloads `infra/docker/.env` into the `lucia` container, and update `.env.lucia.example` comments.


## Testing
- [x] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

### Test Environment
- **OS:** Ubuntu 24.04 (WSL / Linux 6.8.x)
- **Browser:** Chrome (latest) for dashboard verification
- **Node version:** N/A (no changes to frontend build pipeline)

### Manual Tests
- [x] Start fresh environment with `docker compose -f docker-compose.yml -f docker-compose.lucia-sidecar.yml --env-file .env up -d` and verify:
  - Setup wizard is skipped when `DASHBOARD_API_KEY`, `LUCIA_HA_API_KEY`, and `HomeAssistant__*` are set in `.env`.
  - Dashboard login works using the seeded dashboard API key.
  - Home Assistant connection uses values from `.env` on first boot.
  - Default chat and embedding providers are created from `ConnectionStrings__chat-model` / `ConnectionStrings__embeddings`.




## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation/comments where env behavior changed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Additional Notes
- This PR is backward compatible for users who still want to use the setup wizard; headless behavior only takes effect when the relevant `.env` keys are present.
- Existing deployments with populated MongoDB config will continue to use their stored values; the headless seed only runs meaningfully on first boot / empty config.
- For Docker users, it’s now critical to always run with both `docker-compose.yml` and `docker-compose.lucia-sidecar.yml` plus `--env-file infra/docker/.env` for headless mode.

## Breaking Changes
- None expected. The onboarding and configuration flows are additive and guarded by env presence and existing MongoDB state.

## Migration Guide
- To enable headless startup on a fresh deployment:
  1. Copy `infra/docker/.env.lucia.example` to `infra/docker/.env`.
  2. Set `HomeAssistant__BaseUrl`, `HomeAssistant__AccessToken`, `DASHBOARD_API_KEY`, `LUCIA_HA_API_KEY`, and `ConnectionStrings__chat-model` / `ConnectionStrings__embeddings`.
  3. Run `docker compose -f docker-compose.yml -f docker-compose.lucia-sidecar.yml --env-file .env up -d`.
- Existing deployments require no changes; they can optionally adopt `.env`-driven config and restart to migrate to headless mode.

---

**For Reviewers:**
- [x] Code quality and style
- [x] Tests are comprehensive enough for the touched areas
- [x] Documentation/comments are updated where behavior changed
- [x] No security concerns introduced (API keys still hashed; sensitive config stored in Mongo with masking)
- [x] Performance impact is acceptable (single early-seed scope and minor additional config checks)