### PR TITLE
fix(ci): escape regex in docker metadata-action tag pattern

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           images: ${{ matrix.image }}
           tags: |
-            type=match,pattern=(\d{4}\.\d{1,2}\.\d{1,2}.*),group=1
+            type=match,pattern=(20\d{2}\.\d+\.\d+.*),group=1
             type=raw,value={{date 'YYYY.MM.DD'}},enable=${{ github.event_name != 'pull_request' && steps.preview.outputs.is_preview != 'true' }}
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
## Problem

The `type=match` pattern in `docker-build-push.yml` used nested `{1,2}` quantifiers:
```
(\d{4}\.\d{1,2}\.\d{1,2}.*)
```
Docker's `metadata-action` passes this to JavaScript's `RegExp` constructor, which parsed `{1` as an unterminated group, causing:
```
Error: Invalid regular expression: /(\d{4}\.\d{1/: Unterminated group
```

## Fix

Simplified the pattern to:
```
(20\d{2}\.\d+\.\d+.*)
```
This matches the same calendar version tags (`2026.03.06`, `2026.03.06-preview.1`) without nested quantifiers.

## Validation

- `act -n` dry-run passes all 4 matrix builds
- Regex tested in Node.js against all expected tag formats