### PR TITLE
fix(dashboard): fix EntityLocationPage unused variable TS build error

### DIFF
--- a/lucia-dashboard/src/pages/EntityLocationPage.tsx
+++ b/lucia-dashboard/src/pages/EntityLocationPage.tsx
@@ -412,7 +412,7 @@ export default function EntityLocationPage() {
 
   // ── Bulk action bar ───────────────────────────────────────────
 
-  function BulkActionBar({ entityList }: { entityList: EntityLocationInfo[] }) {
+  function BulkActionBar({ entityList: _entityList }: { entityList: EntityLocationInfo[] }) {
     const count = selectedEntityIds.size
     if (count === 0) return null
 


### PR DESCRIPTION
## Problem

Docker image builds fail during the `node-build` stage with:
```
src/pages/EntityLocationPage.tsx(415,26): error TS6133: 'entityList' is declared but its value is never read.
```

The `BulkActionBar` component accepts an `entityList` prop but doesn't use it internally — it only uses `selectedEntityIds` from the parent closure.

## Fix

Prefix the unused destructured parameter with underscore: `{ entityList: _entityList }`

## Validation

- `npx tsc -b --noEmit` — ✅ passes
- `docker build -f ./infra/docker/Dockerfile .` — ✅ full image builds successfully

Closes the build failure from PR #49's CI run.