### PR TITLE
fix(ha-plugin)!: remove deprecated OptionsFlow __init__ and fix linting

### DIFF
--- a/custom_components/lucia/__init__.py
+++ b/custom_components/lucia/__init__.py
@@ -1,9 +1,7 @@
 """The Lucia Home Agent integration."""
 from __future__ import annotations
 
-import json
 import logging
-from typing import Any
 
 import httpx
 
@@ -20,7 +18,6 @@ from .const import (
     CONF_REPOSITORY,
     CONF_VERIFY_SSL,
     DOMAIN,
-    NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/lucia/config_flow.py
+++ b/custom_components/lucia/config_flow.py
@@ -17,9 +17,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
+    NumberSelectorMode,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    SelectOptionDict,
     TemplateSelector,
 )
 
@@ -141,16 +143,11 @@ class LuciaConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
         """Get the options flow for this handler."""
-        return LuciaOptionsFlow(config_entry)
+        return LuciaOptionsFlow()
 
 
 class LuciaOptionsFlow(OptionsFlow):
     """Handle options for Lucia integration."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        super().__init__()
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -164,7 +161,7 @@ class LuciaOptionsFlow(OptionsFlow):
         catalog = entry_data.get("catalog", [])
 
         # Build agent selection options
-        agent_options = []
+        agent_options: list[SelectOptionDict] = []
         for agent in catalog:
             agent_name = agent.get("name", "unknown")
             agent_description = agent.get("description", "")
@@ -172,15 +169,15 @@ class LuciaOptionsFlow(OptionsFlow):
             label = f"{agent_name}"
             if agent_description:
                 label = f"{agent_name} - {agent_description}"
-            agent_options.append({
-                "value": agent_name,
-                "label": label
-            })
+            agent_options.append(SelectOptionDict(
+                value=agent_name,
+                label=label
+            ))
 
         # If no agents found in catalog, show error
         if not agent_options:
             _LOGGER.warning("No agents available in catalog for options flow")
-            agent_options = [{"value": "none", "label": "No agents available"}]
+            agent_options = [SelectOptionDict(value="none", label="No agents available")]
 
         options = self.config_entry.options or {}
 
@@ -213,7 +210,7 @@ class LuciaOptionsFlow(OptionsFlow):
                         min=10,
                         max=4000,
                         step=10,
-                        mode="box",
+                        mode=NumberSelectorMode.BOX,
                     )
                 ),
             }),

--- a/custom_components/lucia/conversation.py
+++ b/custom_components/lucia/conversation.py
@@ -1,15 +1,12 @@
 """Conversation platform for Lucia integration."""
 from __future__ import annotations
 
-import json
 import logging
 import uuid
-from datetime import datetime
 from typing import Any, Literal
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import (
-    ConversationEntity,
     ConversationInput,
     ConversationResult,
 )
@@ -31,20 +28,14 @@ except ImportError:
         _HAS_CHAT_LOG_API = False
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, TemplateError
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import area_registry, device_registry, entity_registry, intent, template
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import ulid, dt as dt_util
+from homeassistant.util import dt as dt_util
 
 from .const import (
-    CONF_MAX_TOKENS,
     CONF_PROMPT,
-    CONF_TEMPERATURE,
-    CONF_TOP_P,
-    DEFAULT_MAX_TOKENS,
     DEFAULT_PROMPT,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
     DOMAIN,
 )
 from .conversation_tracker import ConversationTracker
@@ -128,7 +119,6 @@ class LuciaConversationEntity(conversation.ConversationEntity):
                 continue_conversation=False,
             )
 
-        agent_card = client_data.get("agent_card")
         httpx_client = client_data.get("httpx_client")
         agent_url = client_data.get("agent_url")
 

--- a/custom_components/lucia/test_a2a_local.py
+++ b/custom_components/lucia/test_a2a_local.py
@@ -7,7 +7,7 @@ from a2a.types import Message, Part, Role, TextPart
 
 async def test_agent_catalog(repository_url: str, api_key: str | None):
     """Test fetching the agent catalog from /agents endpoint."""
-    print(f"\n=== Testing Agent Catalog Discovery ===")
+    print("\n=== Testing Agent Catalog Discovery ===")
     print(f"Catalog URL: {repository_url}/agents")
 
     # Create HTTP client with X-Api-Key header if provided
@@ -28,7 +28,7 @@ async def test_agent_catalog(repository_url: str, api_key: str | None):
         response.raise_for_status()
 
         catalog = response.json()
-        print(f"\n✓ Catalog retrieved successfully")
+        print("\n✓ Catalog retrieved successfully")
         print(f"  Status Code: {response.status_code}")
         print(f"  Response Type: {type(catalog)}")
 
@@ -61,7 +61,7 @@ async def test_agent_catalog(repository_url: str, api_key: str | None):
 
 async def test_agent_discovery(repository_url: str, api_key: str | None):
     """Test discovering agents using A2ACardResolver."""
-    print(f"\n=== Testing A2A Agent Discovery ===")
+    print("\n=== Testing A2A Agent Discovery ===")
     print(f"Repository: {repository_url}")
 
     # Create HTTP client with X-Api-Key header if provided
@@ -107,7 +107,7 @@ async def test_agent_discovery(repository_url: str, api_key: str | None):
 
 async def test_send_message(agent_url: str, api_key: str | None, agent_id: str, message_text: str):
     """Test sending a message to an agent."""
-    print(f"\n=== Testing Message Sending ===")
+    print("\n=== Testing Message Sending ===")
     print(f"Agent URL: {agent_url}")
     print(f"Agent ID: {agent_id}")
     print(f"Message: {message_text}")
@@ -151,7 +151,7 @@ async def test_send_message(agent_url: str, api_key: str | None, agent_id: str, 
         # Send message to agent
         response = await client.send_message(request_message)
 
-        print(f"\n✓ Response received:")
+        print("\n✓ Response received:")
         print(f"  Type: {type(response)}")
         if hasattr(response, 'parts'):
             for part in response.parts:
@@ -181,7 +181,7 @@ async def main():
     REPOSITORY_URL = "https://localhost:7235"  # Your agent repository URL
     API_KEY = None  # Set to None if no auth required, or "your-api-key-here"
 
-    print(f"\nConfiguration:")
+    print("\nConfiguration:")
     print(f"  Repository: {REPOSITORY_URL}")
     print(f"  API Key: {'(none)' if not API_KEY else '*' * len(API_KEY)}")
 

--- a/custom_components/lucia/test_catalog_simple.py
+++ b/custom_components/lucia/test_catalog_simple.py
@@ -22,7 +22,7 @@ async def test_catalog_endpoint():
     REPOSITORY_URL = "https://localhost:7235"
     API_KEY = None  # Set if needed
 
-    print(f"\nConfiguration:")
+    print("\nConfiguration:")
     print(f"  Base URL: {REPOSITORY_URL}")
     print(f"  Catalog Endpoint: {REPOSITORY_URL}/agents")
     print(f"  API Key: {'(none)' if not API_KEY else '***'}")
@@ -48,7 +48,7 @@ async def test_catalog_endpoint():
             try:
                 catalog = response.json()
                 print(f"\nCatalog Data Type: {type(catalog)}")
-                print(f"\nFormatted Response:")
+                print("\nFormatted Response:")
                 print(json.dumps(catalog, indent=2))
 
                 # If it's a list, show agent details
@@ -91,7 +91,7 @@ async def test_catalog_endpoint():
                 print(f"Response Text: {response.text[:500]}")
                 return None
         else:
-            print(f"✗ Request failed")
+            print("✗ Request failed")
             print(f"Response: {response.text}")
             return None
 
@@ -130,7 +130,7 @@ async def test_agent_card_endpoint(base_url: str):
 
             try:
                 card = response.json()
-                print(f"\nAgent Card:")
+                print("\nAgent Card:")
                 print(json.dumps(card, indent=2))
                 return card
             except json.JSONDecodeError:
@@ -199,7 +199,7 @@ async def test_message_endpoint(agent_url: str):
 
         openapi_endpoint = f"{agent_url}/v1/message:send"
         print(f"\nTrying endpoint: {openapi_endpoint}")
-        print(f"\nRequest payload:")
+        print("\nRequest payload:")
         print(json.dumps(openapi_request, indent=2))
 
         response = await client.post(
@@ -216,7 +216,7 @@ async def test_message_endpoint(agent_url: str):
 
             try:
                 result = response.json()
-                print(f"\nResponse:")
+                print("\nResponse:")
                 print(json.dumps(result, indent=2))
 
                 # Extract message text if present
@@ -226,13 +226,13 @@ async def test_message_endpoint(agent_url: str):
                     if 'parts' in msg:
                         for part in msg['parts']:
                             if part.get('kind') == 'text':
-                                print(f"\n✓✓✓ SUCCESS! Agent Response Text:")
+                                print("\n✓✓✓ SUCCESS! Agent Response Text:")
                                 print(f"    {part.get('text', '')[:200]}...")
                                 openapi_success = True
                 elif isinstance(result, dict) and 'parts' in result:
                     for part in result['parts']:
                         if part.get('kind') == 'text':
-                            print(f"\n✓✓✓ SUCCESS! Agent Response Text:")
+                            print("\n✓✓✓ SUCCESS! Agent Response Text:")
                             print(f"    {part.get('text', '')[:200]}...")
                             openapi_success = True
 
@@ -243,7 +243,7 @@ async def test_message_endpoint(agent_url: str):
                 print(f"Response Text: {response.text}")
                 return response.text
         else:
-            print(f"✗ Request failed")
+            print("✗ Request failed")
             print(f"Response: {response.text[:500]}")
 
         # Test 2: Also try JSON-RPC format to compare
@@ -273,7 +273,7 @@ async def test_message_endpoint(agent_url: str):
         }
 
         print(f"\nTrying endpoint: {agent_url}")
-        print(f"Method: message/send")
+        print("Method: message/send")
 
         response = await client.post(
             agent_url,
@@ -288,7 +288,7 @@ async def test_message_endpoint(agent_url: str):
 
             try:
                 result = response.json()
-                print(f"\nResponse:")
+                print("\nResponse:")
                 print(json.dumps(result, indent=2))
 
                 # Check for JSON-RPC error
@@ -302,7 +302,7 @@ async def test_message_endpoint(agent_url: str):
                         if 'parts' in res:
                             for part in res['parts']:
                                 if part.get('kind') == 'text':
-                                    print(f"\n✓✓✓ SUCCESS! Agent Response Text:")
+                                    print("\n✓✓✓ SUCCESS! Agent Response Text:")
                                     print(f"    {part.get('text', '')[:200]}...")
                     return result
 

--- a/custom_components/lucia/tests/test_conversation_tracker.py
+++ b/custom_components/lucia/tests/test_conversation_tracker.py
@@ -1,6 +1,5 @@
 """Tests for ConversationTracker and A2A Task/Message parsing."""
 import time
-from unittest.mock import patch
 
 from custom_components.lucia.conversation_tracker import ConversationTracker
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 ﻿{
   "name": "lucia Home Agent",
-  "homeassistant": "2024.5.3b0"
+  "homeassistant": "2024.12.0b0"
 }


### PR DESCRIPTION
## Summary

Fixes a bug reported by a user where the OptionsFlow `__init__` was manually setting `self.config_entry`, which conflicts with HA 2024.12+ where the framework auto-sets it via a property (and HA 2025.12 removes manual assignment entirely).

## Changes

- **Remove `LuciaOptionsFlow.__init__`** — framework now sets `self.config_entry` automatically
- **Use `SelectOptionDict` typed constructor** instead of raw dicts for agent options
- **Use `NumberSelectorMode.BOX` enum** instead of string literal `"box"`
- **Remove unused imports** across all plugin files (`__init__.py`, `conversation.py`, test files)
- **Bump hacs.json minimum** from `2024.5.3b0` → `2024.12.0b0`

## Breaking Change

Minimum Home Assistant version raised to **2024.12.0**. Users on HA < 2024.12 will need to upgrade.

## Validation

- ✅ `ruff check` — 0 errors (was 34)
- ✅ `pyright` — 0 errors on `__init__.py` and `config_flow.py` (was 3)
- ✅ Runtime validation — `LuciaOptionsFlow()` instantiates cleanly on HA 2026.2.3