### PR TITLE
fix(home-assistant): resolve post-merge review feedback from #59

### DIFF
--- a/custom_components/lucia/conversation.py
+++ b/custom_components/lucia/conversation.py
@@ -285,7 +285,6 @@ class LuciaConversationEntity(conversation.ConversationEntity):
                 ha_conversation_id,
                 context_id=response_context_id,
                 task_id=None,
-                last_assistant_text=response_text or None,
             )
 
             _LOGGER.debug("Received response from agent: %s", response_text[:100])

--- a/custom_components/lucia/conversation_tracker.py
+++ b/custom_components/lucia/conversation_tracker.py
@@ -12,7 +12,6 @@ class TrackedConversation:
 
     context_id: str
     task_id: Optional[str] = None
-    last_assistant_text: Optional[str] = None
     expires_at: float = field(default_factory=lambda: time.monotonic() + 300.0)
 
 
@@ -38,16 +37,11 @@ class ConversationTracker:
         conversation_id: str,
         context_id: str,
         task_id: Optional[str] = None,
-        last_assistant_text: Optional[str] = None,
     ) -> None:
         """Store or update a conversation mapping, resetting the TTL."""
-        existing = self._entries.get(conversation_id)
-        # Preserve previous assistant text when updating with a new response
-        assistant_text = last_assistant_text if last_assistant_text is not None else (existing.last_assistant_text if existing else None)
         self._entries[conversation_id] = TrackedConversation(
             context_id=context_id,
             task_id=task_id,
-            last_assistant_text=assistant_text,
             expires_at=time.monotonic() + self._ttl,
         )
 

--- a/scripts/validate-ha-commit.sh
+++ b/scripts/validate-ha-commit.sh
@@ -12,7 +12,16 @@ if [[ -z "$STAGED_FILES" ]]; then
 fi
 
 echo "[pre-commit] Validating UTF-8 (no BOM) for hacs.json..."
-python3 scripts/check_utf8_no_bom.py hacs.json
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_CMD=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_CMD=python
+else
+  echo "[pre-commit] Python (python3 or python) is required to validate hacs.json encoding."
+  exit 1
+fi
+
+"$PYTHON_CMD" scripts/check_utf8_no_bom.py hacs.json
 
 if ! grep -Eq '^(custom_components/lucia/|hacs\.json$)' <<< "$STAGED_FILES"; then
   echo "[pre-commit] No Lucia/HACS files staged; skipping ruff + hassfest."
@@ -20,6 +29,12 @@ if ! grep -Eq '^(custom_components/lucia/|hacs\.json$)' <<< "$STAGED_FILES"; the
 fi
 
 echo "[pre-commit] Running ruff..."
+if ! command -v ruff >/dev/null 2>&1; then
+  echo "[pre-commit] ruff is required to run Python style checks."
+  echo "[pre-commit] Install it with e.g.: pipx install ruff  # or: python3 -m pip install --user ruff"
+  exit 1
+fi
+
 ruff check custom_components/lucia
 
 if ! command -v docker >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- remove dead `last_assistant_text` state from conversation tracker now that follow-ups rely on context/session continuity
- harden `scripts/validate-ha-commit.sh` with explicit Python command detection (`python3`/`python`) and actionable `ruff` dependency checks

## Why
These are follow-up fixes requested in Copilot review threads on merged PR #59.

## Validation
- pre-commit hook on commit (ruff + hassfest): ✅
- `ruff check custom_components/lucia`: ✅
- `docker run --rm -v "$(pwd)":/github/workspace ghcr.io/home-assistant/hassfest`: ✅
