### PR TITLE
feat: entity embedding resiliency with live progress

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 - **Unified Entity Model** — All Home Assistant entity types now share a common `HomeAssistantEntity` base with domain-specific subtypes.
 - **HybridEntityMatcher** — Multi-weighted search combines Levenshtein, Jaro-Winkler, phonetic matching, aliases, and token overlap.
 - **Prompt Cache Overhaul** — Embeddings now persist correctly, routing/chat thresholds are split, and cache settings hot-reload without restart.
+- **Embedding Resiliency + Live Progress** — Entity-location embeddings now generate in throttled background batches, expose SSE progress, and support per-item evict/regenerate controls.
 - **Home Assistant Multi-turn Continuity** — Follow-up conversation flow restored and HA commit validation tightened.
 - **OpenRouter + Discovery** — OpenRouter added as a first-class provider with model discovery support.
 - **Plugin/Setup/Dashboard Stabilization** — Headless setup and HA setup-step UX improvements, plugin installation reliability fixes, and dashboard/tooling cleanup.
@@ -41,6 +42,15 @@
 - **`EntityVisibilityConfig`** — Per-entity visibility settings stored in MongoDB, letting users hide entities from Lucia without removing them from Home Assistant.
 - **`EntityVisibilityApi`** — REST endpoints for bulk visibility management with area/domain filtering.
 - **HA Exposed Entity List** — Support for pulling the pre-filtered exposed entity list from Home Assistant via WebSocket (`homeassistant/expose_entity/list`).
+
+### 📡 Entity Embedding Resiliency + Live Progress
+
+- **Name fallback for embedding safety** — When an entity/floor/area has no name or alias, matchable names now fall back to IDs (entity IDs strip domain and replace `_` with spaces) to avoid invalid empty embedding inputs.
+- **Non-blocking embedding generation** — `EntityLocationService` now loads/cache location data first, then generates embeddings asynchronously in throttled batches with retry/backoff.
+- **Batch embedding pipeline** — Uses provider batch generation (`GenerateAsync(IEnumerable<string>)`) to reduce request pressure and better handle provider-side limits.
+- **Progress API + SSE stream** — Added `/api/entity-location/embedding-progress` and `/api/entity-location/embedding-progress/live` for real-time generation status.
+- **Per-item cache controls** — Added embedding eviction/regeneration endpoints for floors, areas, and entities.
+- **Dashboard live status** — Entity Location page now shows a live generation progress bar, missing-embedding count, and updates without manual refresh.
 
 ### 🧠 Prompt Cache Overhaul
 
@@ -98,12 +108,15 @@
 - **Home Assistant follow-up flow regression** — Fixed continuity and follow-up behavior for multi-turn requests.
 - **Plugin install regressions** — Fixed install path/tooling issues affecting plugin usability.
 - **HACS validation workflow failure** — Corrected CI step order to ensure repository content is present.
+- **Startup embedding failures from blank input** — Prevented invalid embedding calls caused by empty match names.
+- **Embedding request bursts during cache reloads** — Moved generation to throttled background batching to reduce provider rate-limit pressure.
 
 ## 🧪 Testing
 
 - **Playwright e2e test** — `PromptCacheRoutingTests` validates prompt-cache embedding round-trip and semantic route matching behavior.
 - **Embedding diagnostics** — `EmbeddingMatchingTests` measure similarity behavior across synonym/opposite/cross-domain prompt variants.
 - **Plugin/install regression coverage** — Added and updated tests around plugin installability and related dashboard/setup flows.
+- **Name fallback tests** — `EntityMatchNameFormatterTests` validates alias sanitization and ID-based fallback behavior used by embedding inputs.
 
 ## 📋 New Files
 
@@ -128,7 +141,10 @@
 | `lucia.HomeAssistant/Models/ExposedEntityListResponse.cs` | HA WebSocket exposed entity response |
 | `lucia.AgentHost/Apis/EntityVisibilityApi.cs` | Entity visibility REST endpoints |
 | `lucia.AgentHost/Apis/MatcherDebugApi.cs` | Matcher debug/testing REST endpoints |
+| `lucia.Agents/Models/HomeAssistant/EntityLocationEmbeddingProgress.cs` | Embedding coverage/progress snapshot model |
+| `lucia.Agents/Services/EntityMatchNameFormatter.cs` | Safe name/alias formatter with ID fallback |
 | `lucia-dashboard/src/pages/MatcherDebugPage.tsx` | Matcher debug dashboard page |
+| `lucia-dashboard/src/pages/EntityLocationPage.tsx` | Live embedding progress UI + embedding actions |
 | `lucia.PlaywrightTests/Agents/PromptCacheRoutingTests.cs` | Cache embedding e2e test |
 
 ## 🗑️ Removed / Deprecated

--- a/lucia-dashboard/src/api.ts
+++ b/lucia-dashboard/src/api.ts
@@ -849,6 +849,18 @@ export function connectActivityStream(
 
 // ── Entity Location Cache ──────────────────────────────────────────
 
+export interface EntityLocationEmbeddingProgress {
+  floorTotalCount: number
+  floorGeneratedCount: number
+  areaTotalCount: number
+  areaGeneratedCount: number
+  entityTotalCount: number
+  entityGeneratedCount: number
+  entityMissingCount: number
+  isGenerationRunning: boolean
+  lastLoadedAt: string | null
+}
+
 export async function fetchEntityLocationSummary() {
   const res = await fetch(`${BASE}/entity-location`);
   if (!res.ok) throw new Error(`Failed to fetch location summary: ${res.statusText}`);
@@ -884,6 +896,42 @@ export async function searchEntityLocation(term: string, domain?: string) {
 export async function invalidateEntityLocationCache() {
   const res = await fetch(`${BASE}/entity-location/invalidate`, { method: 'POST' });
   if (!res.ok) throw new Error(`Failed to invalidate location cache: ${res.statusText}`);
+  return res.json();
+}
+
+export async function fetchEntityLocationEmbeddingProgress(): Promise<EntityLocationEmbeddingProgress> {
+  const res = await fetch(`${BASE}/entity-location/embedding-progress`);
+  if (!res.ok) throw new Error(`Failed to fetch embedding progress: ${res.statusText}`);
+  return res.json();
+}
+
+export function connectEntityLocationEmbeddingProgressStream(
+  onProgress: (progress: EntityLocationEmbeddingProgress) => void,
+  onError?: (err: Event) => void,
+): EventSource {
+  const source = new EventSource(`${BASE}/entity-location/embedding-progress/live`);
+  source.onmessage = (e) => {
+    try {
+      onProgress(JSON.parse(e.data));
+    } catch { /* ignore parse errors */ }
+  };
+  if (onError) source.onerror = onError;
+  return source;
+}
+
+export async function evictEntityLocationEmbedding(itemType: 'floor' | 'area' | 'entity', itemId: string) {
+  const res = await fetch(`${BASE}/entity-location/embeddings/${encodeURIComponent(itemType)}/${encodeURIComponent(itemId)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error(`Failed to evict embedding: ${res.statusText}`);
+  return res.json();
+}
+
+export async function regenerateEntityLocationEmbedding(itemType: 'floor' | 'area' | 'entity', itemId: string) {
+  const res = await fetch(`${BASE}/entity-location/embeddings/${encodeURIComponent(itemType)}/${encodeURIComponent(itemId)}/regenerate`, {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error(`Failed to regenerate embedding: ${res.statusText}`);
   return res.json();
 }
 

--- a/lucia-dashboard/src/pages/EntityLocationPage.tsx
+++ b/lucia-dashboard/src/pages/EntityLocationPage.tsx
@@ -1,16 +1,21 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   fetchEntityLocationSummary,
+  fetchEntityLocationEmbeddingProgress,
   fetchEntityLocationFloors,
   fetchEntityLocationAreas,
   fetchEntityLocationEntities,
   searchEntityLocation,
+  connectEntityLocationEmbeddingProgressStream,
   invalidateEntityLocationCache,
+  evictEntityLocationEmbedding,
+  regenerateEntityLocationEmbedding,
   fetchEntityVisibility,
   updateVisibilitySettings,
   updateEntityAgents,
   clearAllAgentFilters,
   fetchAvailableAgents,
+  type EntityLocationEmbeddingProgress,
 } from '../api'
 import {
   MapPin, Building2, Layers, Hash, Loader2, RefreshCw, Search, Clock,
@@ -43,6 +48,7 @@ interface EntityLocationInfo {
   aliases: string[]
   areaId: string | null
   platform: string | null
+  embeddingGenerated?: boolean
   includeForAgent: string[] | null
 }
 
@@ -50,6 +56,11 @@ interface LocationSummary {
   floorCount: number
   areaCount: number
   entityCount: number
+  floorEmbeddingsGenerated?: number
+  areaEmbeddingsGenerated?: number
+  entityEmbeddingsGenerated?: number
+  entityEmbeddingsMissing?: number
+  embeddingGenerationInProgress?: boolean
   lastLoadedAt: string | null
 }
 
@@ -91,6 +102,8 @@ export default function EntityLocationPage() {
   const [domainFilter, setDomainFilter] = useState('')
   const [entityPage, setEntityPage] = useState(0)
   const entityPageSize = 50
+  const [embeddingActionKey, setEmbeddingActionKey] = useState<string | null>(null)
+  const [embeddingProgress, setEmbeddingProgress] = useState<EntityLocationEmbeddingProgress | null>(null)
 
   // Visibility state
   const [useExposedOnly, setUseExposedOnly] = useState(false)
@@ -105,6 +118,8 @@ export default function EntityLocationPage() {
   // Per-row agent dropdown
   const [agentDropdownEntityId, setAgentDropdownEntityId] = useState<string | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const embeddingStreamRef = useRef<EventSource | null>(null)
+  const embeddingGenerationWasRunningRef = useRef(false)
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -126,6 +141,33 @@ export default function EntityLocationPage() {
       setError(err instanceof Error ? err.message : 'Failed to load summary')
     }
   }, [])
+
+  const applyEmbeddingProgress = useCallback((progress: EntityLocationEmbeddingProgress) => {
+    setEmbeddingProgress(progress)
+    setSummary(prev => {
+      if (!prev) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        floorEmbeddingsGenerated: progress.floorGeneratedCount,
+        areaEmbeddingsGenerated: progress.areaGeneratedCount,
+        entityEmbeddingsGenerated: progress.entityGeneratedCount,
+        entityEmbeddingsMissing: progress.entityMissingCount,
+        embeddingGenerationInProgress: progress.isGenerationRunning,
+      }
+    })
+  }, [])
+
+  const loadEmbeddingProgress = useCallback(async () => {
+    try {
+      const progress = await fetchEntityLocationEmbeddingProgress()
+      applyEmbeddingProgress(progress)
+    } catch {
+      // Non-fatal; SSE stream may still reconnect and provide updates.
+    }
+  }, [applyEmbeddingProgress])
 
   const loadVisibility = useCallback(async () => {
     try {
@@ -160,13 +202,47 @@ export default function EntityLocationPage() {
 
   useEffect(() => {
     loadSummary()
+    loadEmbeddingProgress()
     loadVisibility()
     loadTab('floors')
-  }, [loadSummary, loadVisibility, loadTab])
+  }, [loadSummary, loadEmbeddingProgress, loadVisibility, loadTab])
 
   useEffect(() => {
     if (activeTab !== 'search') loadTab(activeTab)
   }, [activeTab, loadTab])
+
+  useEffect(() => {
+    const source = connectEntityLocationEmbeddingProgressStream(
+      (progress) => {
+        applyEmbeddingProgress(progress)
+      },
+      () => {
+        // EventSource auto-reconnects; avoid noisy UI errors for transient disconnects.
+      },
+    )
+
+    embeddingStreamRef.current = source
+
+    return () => {
+      source.close()
+      if (embeddingStreamRef.current === source) {
+        embeddingStreamRef.current = null
+      }
+    }
+  }, [applyEmbeddingProgress])
+
+  useEffect(() => {
+    if (!embeddingProgress) {
+      return
+    }
+
+    const wasRunning = embeddingGenerationWasRunningRef.current
+    embeddingGenerationWasRunningRef.current = embeddingProgress.isGenerationRunning
+
+    if (wasRunning && !embeddingProgress.isGenerationRunning && activeTab === 'entities') {
+      void loadTab('entities')
+    }
+  }, [embeddingProgress, activeTab, loadTab])
 
   async function handleInvalidate() {
     if (!confirm('Invalidate and reload all location data from Home Assistant?')) return
@@ -174,7 +250,7 @@ export default function EntityLocationPage() {
     setError(null)
     try {
       await invalidateEntityLocationCache()
-      await Promise.all([loadSummary(), loadVisibility()])
+      await Promise.all([loadSummary(), loadEmbeddingProgress(), loadVisibility()])
       await loadTab(activeTab)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to invalidate cache')
@@ -209,6 +285,37 @@ export default function EntityLocationPage() {
       setError(err instanceof Error ? err.message : 'Search failed')
     } finally {
       setSearching(false)
+    }
+  }
+
+  async function handleEvictEmbedding(entityId: string) {
+    if (!confirm(`Evict cached embedding for "${entityId}"?`)) return
+    setEmbeddingActionKey(`${entityId}:evict`)
+    setError(null)
+    try {
+      await evictEntityLocationEmbedding('entity', entityId)
+      setEntities(prev => prev.map(e => e.entityId === entityId ? { ...e, embeddingGenerated: false } : e))
+      setSearchResults(prev => prev.map(e => e.entityId === entityId ? { ...e, embeddingGenerated: false } : e))
+      await loadSummary()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to evict embedding')
+    } finally {
+      setEmbeddingActionKey(null)
+    }
+  }
+
+  async function handleRegenerateEmbedding(entityId: string) {
+    setEmbeddingActionKey(`${entityId}:regenerate`)
+    setError(null)
+    try {
+      await regenerateEntityLocationEmbedding('entity', entityId)
+      setEntities(prev => prev.map(e => e.entityId === entityId ? { ...e, embeddingGenerated: true } : e))
+      setSearchResults(prev => prev.map(e => e.entityId === entityId ? { ...e, embeddingGenerated: true } : e))
+      await loadSummary()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to regenerate embedding')
+    } finally {
+      setEmbeddingActionKey(null)
     }
   }
 
@@ -523,7 +630,9 @@ export default function EntityLocationPage() {
               <th className="px-4 py-3">Friendly Name</th>
               <th className="px-4 py-3">Domain</th>
               <th className="px-4 py-3">Area</th>
+              <th className="px-4 py-3">Embedding</th>
               <th className="px-4 py-3">Agents</th>
+              <th className="px-4 py-3">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-stone/50">
@@ -546,13 +655,42 @@ export default function EntityLocationPage() {
                 <td className="px-4 py-3"><Badge>{e.domain}</Badge></td>
                 <td className="px-4 py-3 text-fog">{e.areaId ?? '—'}</td>
                 <td className="px-4 py-3">
+                  {e.embeddingGenerated
+                    ? <Badge color="sage">Generated</Badge>
+                    : <Badge color="rose">Missing</Badge>}
+                </td>
+                <td className="px-4 py-3">
                   <AgentDropdown entityId={e.entityId} />
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => handleRegenerateEmbedding(e.entityId)}
+                      disabled={embeddingActionKey !== null}
+                      className="rounded-md p-1 text-sky-400 transition-colors hover:bg-sky-400/15 disabled:opacity-40"
+                      title="Regenerate embedding"
+                    >
+                      {embeddingActionKey === `${e.entityId}:regenerate`
+                        ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        : <RefreshCw className="h-3.5 w-3.5" />}
+                    </button>
+                    <button
+                      onClick={() => handleEvictEmbedding(e.entityId)}
+                      disabled={embeddingActionKey !== null}
+                      className="rounded-md p-1 text-rose transition-colors hover:bg-rose/15 disabled:opacity-40"
+                      title="Evict cached embedding"
+                    >
+                      {embeddingActionKey === `${e.entityId}:evict`
+                        ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        : <Trash2 className="h-3.5 w-3.5" />}
+                    </button>
+                  </div>
                 </td>
               </tr>
             ))}
             {entityList.length === 0 && (
               <tr>
-                <td colSpan={showSelect ? 6 : 5} className="px-4 py-12 text-center text-dust">
+                <td colSpan={showSelect ? 8 : 7} className="px-4 py-12 text-center text-dust">
                   No entities found.
                 </td>
               </tr>
@@ -562,6 +700,17 @@ export default function EntityLocationPage() {
       </div>
     )
   }
+
+  const entityTotalForProgress = embeddingProgress?.entityTotalCount ?? summary?.entityCount ?? 0
+  const entityGeneratedForProgress = embeddingProgress?.entityGeneratedCount ?? summary?.entityEmbeddingsGenerated ?? 0
+  const entityMissingForProgress = embeddingProgress?.entityMissingCount
+    ?? Math.max(entityTotalForProgress - entityGeneratedForProgress, 0)
+  const entityProgressPercent = entityTotalForProgress > 0
+    ? Math.round((entityGeneratedForProgress / entityTotalForProgress) * 100)
+    : 0
+  const embeddingGenerationInProgress = embeddingProgress?.isGenerationRunning
+    ?? summary?.embeddingGenerationInProgress
+    ?? false
 
   return (
     <div className="space-y-6">
@@ -635,6 +784,9 @@ export default function EntityLocationPage() {
               <span className="text-xs font-medium uppercase tracking-wider text-dust">Entities</span>
             </div>
             <p className="font-display text-2xl font-bold text-sky-400">{summary.entityCount}</p>
+            <p className="mt-1 text-xs text-dust">
+              Embeddings: {summary.entityEmbeddingsGenerated ?? 0}/{summary.entityCount}
+            </p>
           </div>
           <div className="glass-panel rounded-xl p-4">
             <div className="mb-1 flex items-center gap-1.5">
@@ -643,6 +795,33 @@ export default function EntityLocationPage() {
             </div>
             <p className="text-sm font-medium text-fog">{formatDate(summary.lastLoadedAt)}</p>
           </div>
+        </div>
+      )}
+
+      {summary && (
+        <div className="glass-panel rounded-xl p-4">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-light">Entity Embedding Generation</span>
+              {embeddingGenerationInProgress
+                ? <Badge color="amber">In Progress</Badge>
+                : <Badge color="sage">Idle</Badge>}
+            </div>
+            <span className="text-xs text-dust">
+              Missing embeddings: {entityMissingForProgress} / {entityTotalForProgress}
+            </span>
+          </div>
+
+          <div className="h-2 w-full overflow-hidden rounded-full bg-stone/50">
+            <div
+              className="h-full rounded-full bg-sky-400 transition-all duration-300"
+              style={{ width: `${Math.min(entityProgressPercent, 100)}%` }}
+            />
+          </div>
+
+          <p className="mt-2 text-xs text-dust">
+            Generated {entityGeneratedForProgress} of {entityTotalForProgress} ({entityProgressPercent}%)
+          </p>
         </div>
       )}
 

--- a/lucia.AgentHost/Apis/EntityLocationCacheApi.cs
+++ b/lucia.AgentHost/Apis/EntityLocationCacheApi.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using lucia.Agents.Abstractions;
+using lucia.Agents.Models.HomeAssistant;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,6 +11,14 @@ namespace lucia.AgentHost.Apis;
 /// </summary>
 public static class EntityLocationCacheApi
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly TimeSpan EmbeddingProgressSseInterval = TimeSpan.FromMilliseconds(750);
+
     public static IEndpointRouteBuilder MapEntityLocationCacheApi(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/entity-location")
@@ -20,7 +30,11 @@ public static class EntityLocationCacheApi
         group.MapGet("/areas", GetAreasAsync);
         group.MapGet("/entities", GetEntitiesAsync);
         group.MapGet("/search/{term}", SearchAsync);
+        group.MapGet("/embedding-progress", GetEmbeddingProgressAsync);
+        group.MapGet("/embedding-progress/live", StreamEmbeddingProgressAsync);
         group.MapPost("/invalidate", InvalidateAsync);
+        group.MapDelete("/embeddings/{itemType}/{itemId}", EvictEmbeddingAsync);
+        group.MapPost("/embeddings/{itemType}/{itemId}/regenerate", RegenerateEmbeddingAsync);
 
         return endpoints;
     }
@@ -32,14 +46,61 @@ public static class EntityLocationCacheApi
         var floors = await locationService.GetFloorsAsync(ct).ConfigureAwait(false);
         var areas = await locationService.GetAreasAsync(ct).ConfigureAwait(false);
         var entities = await locationService.GetEntitiesAsync(ct).ConfigureAwait(false);
+        var embeddingProgress = await locationService.GetEmbeddingProgressAsync(ct).ConfigureAwait(false);
 
         return TypedResults.Ok<object>(new
         {
             floorCount = floors.Count,
             areaCount = areas.Count,
             entityCount = entities.Count,
+            floorEmbeddingsGenerated = embeddingProgress.FloorGeneratedCount,
+            areaEmbeddingsGenerated = embeddingProgress.AreaGeneratedCount,
+            entityEmbeddingsGenerated = embeddingProgress.EntityGeneratedCount,
+            entityEmbeddingsMissing = embeddingProgress.EntityMissingCount,
+            embeddingGenerationInProgress = embeddingProgress.IsGenerationRunning,
             lastLoadedAt = locationService.LastLoadedAt?.ToString("O")
         });
+    }
+
+    private static async Task<Ok<EntityLocationEmbeddingProgress>> GetEmbeddingProgressAsync(
+        [FromServices] IEntityLocationService locationService,
+        CancellationToken ct)
+    {
+        var progress = await locationService.GetEmbeddingProgressAsync(ct).ConfigureAwait(false);
+        return TypedResults.Ok(progress);
+    }
+
+    private static async Task StreamEmbeddingProgressAsync(
+        [FromServices] IEntityLocationService locationService,
+        HttpContext ctx,
+        CancellationToken ct)
+    {
+        ctx.Response.ContentType = "text/event-stream";
+        ctx.Response.Headers.CacheControl = "no-cache";
+        ctx.Response.Headers.Connection = "keep-alive";
+
+        string? previousPayload = null;
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var progress = await locationService.GetEmbeddingProgressAsync(ct).ConfigureAwait(false);
+                var payload = JsonSerializer.Serialize(progress, JsonOptions);
+                if (!string.Equals(payload, previousPayload, StringComparison.Ordinal))
+                {
+                    await ctx.Response.WriteAsync($"data: {payload}\n\n", ct).ConfigureAwait(false);
+                    await ctx.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                    previousPayload = payload;
+                }
+
+                await Task.Delay(EmbeddingProgressSseInterval, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Client disconnected.
+        }
     }
 
     private static async Task<Ok<object>> GetFloorsAsync(
@@ -56,6 +117,7 @@ public static class EntityLocationCacheApi
             f.Aliases,
             f.Level,
             f.Icon,
+            embeddingGenerated = f.NameEmbedding is not null,
             AreaCount = areas.Count(a => a.FloorId == f.FloorId),
             Areas = areas.Where(a => a.FloorId == f.FloorId).Select(a => a.Name)
         });
@@ -77,6 +139,7 @@ public static class EntityLocationCacheApi
             a.Aliases,
             a.Icon,
             a.Labels,
+            embeddingGenerated = a.NameEmbedding is not null,
             EntityCount = a.EntityIds.Count
         });
 
@@ -101,6 +164,7 @@ public static class EntityLocationCacheApi
             e.Domain,
             e.Aliases,
             e.AreaId,
+            embeddingGenerated = e.NameEmbedding is not null,
             AreaName = e.AreaId is not null ? locationService.GetAreaForEntity(e.EntityId)?.Name : null,
             FloorName = e.AreaId is not null ? locationService.GetFloorForArea(
                 locationService.GetAreaForEntity(e.EntityId)?.AreaId ?? "")?.Name : null,
@@ -134,6 +198,7 @@ public static class EntityLocationCacheApi
                 e.Entity.FriendlyName,
                 e.Entity.Domain,
                 e.Entity.AreaId,
+                embeddingGenerated = e.Entity.NameEmbedding is not null,
                 AreaName = e.Entity.AreaId is not null ? locationService.GetAreaForEntity(e.Entity.EntityId)?.Name : null
             })
         });
@@ -156,6 +221,67 @@ public static class EntityLocationCacheApi
             areaCount = areas.Count,
             entityCount = entities.Count,
             lastLoadedAt = locationService.LastLoadedAt?.ToString("O")
+        });
+    }
+
+    private static async Task<Results<Ok<object>, NotFound<object>>> EvictEmbeddingAsync(
+        [FromServices] IEntityLocationService locationService,
+        [FromRoute] string itemType,
+        [FromRoute] string itemId,
+        CancellationToken ct)
+    {
+        var success = await locationService.EvictEmbeddingAsync(itemType, itemId, ct).ConfigureAwait(false);
+        if (!success)
+        {
+            return TypedResults.NotFound<object>(new
+            {
+                message = "Item not found",
+                itemType,
+                itemId
+            });
+        }
+
+        return TypedResults.Ok<object>(new
+        {
+            message = "Embedding evicted",
+            itemType,
+            itemId
+        });
+    }
+
+    private static async Task<Results<Ok<object>, NotFound<object>, BadRequest<object>>> RegenerateEmbeddingAsync(
+        [FromServices] IEntityLocationService locationService,
+        [FromRoute] string itemType,
+        [FromRoute] string itemId,
+        CancellationToken ct)
+    {
+        var evicted = await locationService.EvictEmbeddingAsync(itemType, itemId, ct).ConfigureAwait(false);
+        if (!evicted)
+        {
+            return TypedResults.NotFound<object>(new
+            {
+                message = "Item not found",
+                itemType,
+                itemId
+            });
+        }
+
+        var regenerated = await locationService.RegenerateEmbeddingAsync(itemType, itemId, ct).ConfigureAwait(false);
+        if (!regenerated)
+        {
+            return TypedResults.BadRequest<object>(new
+            {
+                message = "Embedding regeneration failed",
+                itemType,
+                itemId
+            });
+        }
+
+        return TypedResults.Ok<object>(new
+        {
+            message = "Embedding regenerated",
+            itemType,
+            itemId
         });
     }
 }

--- a/lucia.Agents/Abstractions/IEntityLocationService.cs
+++ b/lucia.Agents/Abstractions/IEntityLocationService.cs
@@ -139,4 +139,21 @@ public interface IEntityLocationService
     /// Clear all per-entity agent filters, resetting every entity to visible-to-all.
     /// </summary>
     Task ClearAllAgentFiltersAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Evict a cached embedding for a floor, area, or entity.
+    /// Valid itemType values: <c>floor</c>, <c>area</c>, <c>entity</c>.
+    /// </summary>
+    Task<bool> EvictEmbeddingAsync(string itemType, string itemId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Regenerate a cached embedding for a floor, area, or entity.
+    /// Valid itemType values: <c>floor</c>, <c>area</c>, <c>entity</c>.
+    /// </summary>
+    Task<bool> RegenerateEmbeddingAsync(string itemType, string itemId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get current embedding generation progress across floors, areas, and entities.
+    /// </summary>
+    Task<EntityLocationEmbeddingProgress> GetEmbeddingProgressAsync(CancellationToken ct = default);
 }

--- a/lucia.Agents/Models/HomeAssistant/EntityLocationEmbeddingProgress.cs
+++ b/lucia.Agents/Models/HomeAssistant/EntityLocationEmbeddingProgress.cs
@@ -1,0 +1,17 @@
+namespace lucia.Agents.Models.HomeAssistant;
+
+/// <summary>
+/// Snapshot of embedding generation coverage and progress for the entity location cache.
+/// </summary>
+public sealed class EntityLocationEmbeddingProgress
+{
+    public required int FloorTotalCount { get; init; }
+    public required int FloorGeneratedCount { get; init; }
+    public required int AreaTotalCount { get; init; }
+    public required int AreaGeneratedCount { get; init; }
+    public required int EntityTotalCount { get; init; }
+    public required int EntityGeneratedCount { get; init; }
+    public required int EntityMissingCount { get; init; }
+    public required bool IsGenerationRunning { get; init; }
+    public DateTimeOffset? LastLoadedAt { get; init; }
+}

--- a/lucia.Agents/Services/EntityLocationService.cs
+++ b/lucia.Agents/Services/EntityLocationService.cs
@@ -31,6 +31,10 @@ public sealed class EntityLocationService : IEntityLocationService
     private const string VisibilityKey = "lucia:entity-visibility";
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
     private static readonly TimeSpan VersionCheckInterval = TimeSpan.FromSeconds(30);
+    private const int EmbeddingBatchSize = 25;
+    private const int EmbeddingBatchMaxAttempts = 3;
+    private static readonly TimeSpan EmbeddingBatchDelay = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan EmbeddingRetryDelay = TimeSpan.FromSeconds(1);
 
     private static readonly HybridMatchOptions DefaultLocationOptions = new()
     {
@@ -51,6 +55,12 @@ public sealed class EntityLocationService : IEntityLocationService
     private readonly IHybridEntityMatcher _entityMatcher;
     private readonly ILogger<EntityLocationService> _logger;
     private readonly SemaphoreSlim _loadLock = new(1, 1);
+    private readonly object _embeddingJobGate = new();
+    private CancellationTokenSource? _embeddingJobCts;
+    private Task? _embeddingJobTask;
+    private long _embeddingJobCounter;
+    private long _activeEmbeddingJobId;
+    private int _isEmbeddingGenerationRunning;
 
     private static readonly TimeSpan EmptyCacheRetryInterval = TimeSpan.FromSeconds(30);
 
@@ -69,6 +79,29 @@ public sealed class EntityLocationService : IEntityLocationService
             var ticks = Volatile.Read(ref _lastLoadedAtTicks);
             return ticks == 0 ? null : new DateTimeOffset(ticks, TimeSpan.Zero);
         }
+    }
+
+    public Task<EntityLocationEmbeddingProgress> GetEmbeddingProgressAsync(CancellationToken ct = default)
+    {
+        var snap = _snapshot;
+        var floorGeneratedCount = snap.Floors.Count(f => f.NameEmbedding is not null);
+        var areaGeneratedCount = snap.Areas.Count(a => a.NameEmbedding is not null);
+        var entityGeneratedCount = snap.Entities.Count(e => e.NameEmbedding is not null);
+
+        var progress = new EntityLocationEmbeddingProgress
+        {
+            FloorTotalCount = snap.Floors.Length,
+            FloorGeneratedCount = floorGeneratedCount,
+            AreaTotalCount = snap.Areas.Length,
+            AreaGeneratedCount = areaGeneratedCount,
+            EntityTotalCount = snap.Entities.Length,
+            EntityGeneratedCount = entityGeneratedCount,
+            EntityMissingCount = Math.Max(snap.Entities.Length - entityGeneratedCount, 0),
+            IsGenerationRunning = Volatile.Read(ref _isEmbeddingGenerationRunning) == 1,
+            LastLoadedAt = LastLoadedAt
+        };
+
+        return Task.FromResult(progress);
     }
 
     public EntityLocationService(
@@ -102,6 +135,7 @@ public sealed class EntityLocationService : IEntityLocationService
         {
             ApplyVisibilityToEntities();
             var snap = _snapshot;
+            StartEmbeddingGenerationJob(snap.Floors, snap.Areas, snap.Entities);
             _logger.LogInformation(
                 "Loaded location data from Redis: {FloorCount} floors, {AreaCount} areas, {EntityCount} entities",
                 snap.Floors.Length, snap.Areas.Length, snap.Entities.Length);
@@ -512,8 +546,8 @@ public sealed class EntityLocationService : IEntityLocationService
             var areas = BuildAreas(areaEntries, areaEntityMap);
             var entities = BuildEntities(entityEntries, areaEntityMap);
 
-            // Generate embeddings and phonetic keys for all matchable objects
-            await GenerateMatchDataAsync(floors, areas, entities, ct).ConfigureAwait(false);
+            // Generate phonetic keys eagerly; embeddings are generated in a throttled background job.
+            GeneratePhoneticData(floors, areas, entities);
 
             // Atomic swap of all collections
             SwapData(floors, areas, entities);
@@ -527,6 +561,9 @@ public sealed class EntityLocationService : IEntityLocationService
 
             // Persist to Redis
             await SaveToRedisAsync(ct).ConfigureAwait(false);
+
+            // Generate embeddings asynchronously in throttled batches.
+            StartEmbeddingGenerationJob(floors, areas, entities);
         }
         catch (Exception ex)
         {
@@ -571,8 +608,11 @@ public sealed class EntityLocationService : IEntityLocationService
             ..entries.Select(f => new FloorInfo
             {
                 FloorId = f.FloorId,
-                Name = f.Name,
-                Aliases = f.Aliases.AsReadOnly(),
+                Aliases = EntityMatchNameFormatter.SanitizeAliases(f.Aliases).AsReadOnly(),
+                Name = EntityMatchNameFormatter.ResolveName(
+                    f.Name,
+                    f.Aliases,
+                    f.FloorId),
                 Level = f.Level,
                 Icon = f.Icon
             })
@@ -587,9 +627,12 @@ public sealed class EntityLocationService : IEntityLocationService
             ..entries.Select(a => new AreaInfo
             {
                 AreaId = a.AreaId,
-                Name = a.Name,
+                Name = EntityMatchNameFormatter.ResolveName(
+                    a.Name,
+                    a.Aliases,
+                    a.AreaId),
                 FloorId = a.FloorId,
-                Aliases = a.Aliases.AsReadOnly(),
+                Aliases = EntityMatchNameFormatter.SanitizeAliases(a.Aliases).AsReadOnly(),
                 EntityIds = areaEntityMap.TryGetValue(a.AreaId, out var entityIds)
                     ? entityIds.AsReadOnly()
                     : [],
@@ -619,8 +662,12 @@ public sealed class EntityLocationService : IEntityLocationService
                 .Select(e => new HomeAssistantEntity
                 {
                     EntityId = e.EntityId,
-                    FriendlyName = e.Name ?? e.OriginalName ?? e.EntityId,
-                    Aliases = e.Aliases.AsReadOnly(),
+                    FriendlyName = EntityMatchNameFormatter.ResolveName(
+                        e.Name ?? e.OriginalName,
+                        e.Aliases,
+                        e.EntityId,
+                        stripDomainFromId: true),
+                    Aliases = EntityMatchNameFormatter.SanitizeAliases(e.Aliases).AsReadOnly(),
                     // Prefer Jinja area (device-inherited), fall back to registry direct assignment
                     AreaId = entityToArea.TryGetValue(e.EntityId, out var jinjaArea)
                         ? jinjaArea
@@ -631,17 +678,11 @@ public sealed class EntityLocationService : IEntityLocationService
         ];
     }
 
-    /// <summary>
-    /// Generates embeddings and phonetic keys for all matchable objects
-    /// (floors, areas, and entities) so the HybridEntityMatcher can score them.
-    /// </summary>
-    private async Task GenerateMatchDataAsync(
+    private void GeneratePhoneticData(
         ImmutableArray<FloorInfo> floors,
         ImmutableArray<AreaInfo> areas,
-        ImmutableArray<HomeAssistantEntity> entities,
-        CancellationToken ct)
+        ImmutableArray<HomeAssistantEntity> entities)
     {
-        // Phonetic keys are always generated (no external service needed)
         foreach (var floor in floors)
         {
             floor.PhoneticKeys = StringSimilarity.BuildPhoneticKeys(floor.Name);
@@ -659,54 +700,179 @@ public sealed class EntityLocationService : IEntityLocationService
             entity.PhoneticKeys = StringSimilarity.BuildPhoneticKeys(entity.FriendlyName);
             entity.AliasPhoneticKeys = BuildAliasPhoneticKeys(entity.Aliases);
         }
+    }
 
-        // Embeddings require an embedding provider
-        var embeddingService = await _embeddingResolver.ResolveAsync(ct: ct).ConfigureAwait(false);
-        if (embeddingService is null)
+    private void StartEmbeddingGenerationJob(
+        ImmutableArray<FloorInfo> floors,
+        ImmutableArray<AreaInfo> areas,
+        ImmutableArray<HomeAssistantEntity> entities)
+    {
+        lock (_embeddingJobGate)
         {
-            _logger.LogWarning("No embedding provider available — embedding-based search will be disabled");
-            return;
+            _embeddingJobCts?.Cancel();
+            _embeddingJobCts?.Dispose();
+
+            var cts = new CancellationTokenSource();
+            _embeddingJobCts = cts;
+            var jobId = Interlocked.Increment(ref _embeddingJobCounter);
+            Volatile.Write(ref _activeEmbeddingJobId, jobId);
+            Volatile.Write(ref _isEmbeddingGenerationRunning, 1);
+            _embeddingJobTask = Task.Run(
+                () => RunEmbeddingGenerationJobAsync(floors, areas, entities, jobId, cts.Token),
+                cts.Token);
         }
+    }
 
-        // Collect all unique names to embed (deduplicate across floors/areas/entities)
-        var namesToEmbed = new Dictionary<string, List<Action<Embedding<float>>>>(StringComparer.OrdinalIgnoreCase);
-
-        void RegisterForEmbedding(string name, Action<Embedding<float>> setter)
+    private async Task RunEmbeddingGenerationJobAsync(
+        ImmutableArray<FloorInfo> floors,
+        ImmutableArray<AreaInfo> areas,
+        ImmutableArray<HomeAssistantEntity> entities,
+        long jobId,
+        CancellationToken ct)
+    {
+        try
         {
-            if (!namesToEmbed.TryGetValue(name, out var setters))
+            var embeddingService = await _embeddingResolver.ResolveAsync(ct: ct).ConfigureAwait(false);
+            if (embeddingService is null)
             {
-                setters = [];
-                namesToEmbed[name] = setters;
+                _logger.LogWarning("No embedding provider available — embedding-based search will be disabled");
+                return;
             }
-            setters.Add(setter);
+
+            var namesToEmbed = new Dictionary<string, List<Action<Embedding<float>>>>(StringComparer.OrdinalIgnoreCase);
+
+            void RegisterForEmbedding(string name, Action<Embedding<float>> setter, bool hasEmbedding)
+            {
+                if (hasEmbedding || string.IsNullOrWhiteSpace(name))
+                {
+                    return;
+                }
+
+                if (!namesToEmbed.TryGetValue(name, out var setters))
+                {
+                    setters = [];
+                    namesToEmbed[name] = setters;
+                }
+
+                setters.Add(setter);
+            }
+
+            foreach (var floor in floors)
+            {
+                RegisterForEmbedding(floor.Name, e => floor.NameEmbedding = e, floor.NameEmbedding is not null);
+            }
+
+            foreach (var area in areas)
+            {
+                RegisterForEmbedding(area.Name, e => area.NameEmbedding = e, area.NameEmbedding is not null);
+            }
+
+            foreach (var entity in entities)
+            {
+                RegisterForEmbedding(entity.FriendlyName, e => entity.NameEmbedding = e, entity.NameEmbedding is not null);
+            }
+
+            if (namesToEmbed.Count == 0)
+            {
+                _logger.LogDebug("Embedding cache already complete for current location snapshot");
+                return;
+            }
+
+            var names = namesToEmbed.Keys.ToList();
+            var generated = 0;
+
+            for (var offset = 0; offset < names.Count; offset += EmbeddingBatchSize)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var batchNames = names.Skip(offset).Take(EmbeddingBatchSize).ToArray();
+                var batchEmbeddings = await TryGenerateBatchWithRetryAsync(embeddingService, batchNames, ct).ConfigureAwait(false);
+                if (batchEmbeddings is null)
+                {
+                    continue;
+                }
+
+                var count = Math.Min(batchNames.Length, batchEmbeddings.Count);
+                for (var i = 0; i < count; i++)
+                {
+                    if (!namesToEmbed.TryGetValue(batchNames[i], out var setters))
+                    {
+                        continue;
+                    }
+
+                    foreach (var setter in setters)
+                    {
+                        setter(CloneEmbedding(batchEmbeddings[i]));
+                    }
+
+                    generated++;
+                }
+
+                await PersistEmbeddingUpdatesAsync(ct).ConfigureAwait(false);
+
+                if (offset + EmbeddingBatchSize < names.Count)
+                {
+                    await Task.Delay(EmbeddingBatchDelay, ct).ConfigureAwait(false);
+                }
+            }
+
+            _logger.LogInformation(
+                "Generated {GeneratedCount} embeddings for location snapshot (requested {RequestedCount})",
+                generated,
+                namesToEmbed.Count);
         }
-
-        foreach (var floor in floors)
-            RegisterForEmbedding(floor.Name, e => floor.NameEmbedding = e);
-
-        foreach (var area in areas)
-            RegisterForEmbedding(area.Name, e => area.NameEmbedding = e);
-
-        foreach (var entity in entities)
-            RegisterForEmbedding(entity.FriendlyName, e => entity.NameEmbedding = e);
-
-        int generated = 0;
-        foreach (var (name, setters) in namesToEmbed)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+            _logger.LogDebug("Embedding generation job cancelled");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Background embedding generation failed");
+        }
+        finally
+        {
+            if (Volatile.Read(ref _activeEmbeddingJobId) == jobId)
+            {
+                Volatile.Write(ref _isEmbeddingGenerationRunning, 0);
+            }
+        }
+    }
+
+    private async Task<GeneratedEmbeddings<Embedding<float>>?> TryGenerateBatchWithRetryAsync(
+        IEmbeddingGenerator<string, Embedding<float>> embeddingService,
+        string[] batchNames,
+        CancellationToken ct)
+    {
+        for (var attempt = 1; attempt <= EmbeddingBatchMaxAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+
             try
             {
-                var embedding = await embeddingService.GenerateAsync(name, cancellationToken: ct).ConfigureAwait(false);
-                foreach (var setter in setters)
-                    setter(CloneEmbedding(embedding));
-                generated++;
+                return await embeddingService.GenerateAsync(batchNames, cancellationToken: ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (attempt < EmbeddingBatchMaxAttempts)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Embedding batch failed on attempt {Attempt}/{MaxAttempts}; retrying in {DelayMs}ms",
+                    attempt,
+                    EmbeddingBatchMaxAttempts,
+                    EmbeddingRetryDelay.TotalMilliseconds);
+                await Task.Delay(EmbeddingRetryDelay, ct).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to generate embedding for '{Name}'", name);
+                _logger.LogWarning(
+                    ex,
+                    "Embedding batch failed after {MaxAttempts} attempts for {ItemCount} items",
+                    EmbeddingBatchMaxAttempts,
+                    batchNames.Length);
+                return null;
             }
         }
 
-        _logger.LogDebug("Generated {Count} embeddings for {UniqueNames} unique names", generated, namesToEmbed.Count);
+        return null;
     }
     
     private static Embedding<float> CloneEmbedding(Embedding<float> source)
@@ -849,6 +1015,8 @@ public sealed class EntityLocationService : IEntityLocationService
             if (await TryLoadFromRedisAsync(ct).ConfigureAwait(false))
             {
                 CacheReloads.Add(1);
+                var snap = _snapshot;
+                StartEmbeddingGenerationJob(snap.Floors, snap.Areas, snap.Entities);
             }
         }
         catch (RedisException ex)
@@ -872,6 +1040,12 @@ public sealed class EntityLocationService : IEntityLocationService
         {
             _logger.LogWarning(ex, "Failed to bump Redis location cache version");
         }
+    }
+
+    private async Task PersistEmbeddingUpdatesAsync(CancellationToken ct)
+    {
+        await SaveToRedisAsync(ct).ConfigureAwait(false);
+        await BumpRedisVersionAsync().ConfigureAwait(false);
     }
 
     private async Task SaveToRedisAsync(CancellationToken ct)
@@ -955,6 +1129,56 @@ public sealed class EntityLocationService : IEntityLocationService
         await BumpRedisVersionAsync().ConfigureAwait(false);
     }
 
+    public async Task<bool> EvictEmbeddingAsync(string itemType, string itemId, CancellationToken ct = default)
+    {
+        if (!TryResolveEmbeddingTarget(itemType, itemId, out _, out var setEmbedding))
+        {
+            return false;
+        }
+
+        setEmbedding(null);
+        await PersistEmbeddingUpdatesAsync(ct).ConfigureAwait(false);
+        return true;
+    }
+
+    public async Task<bool> RegenerateEmbeddingAsync(string itemType, string itemId, CancellationToken ct = default)
+    {
+        if (!TryResolveEmbeddingTarget(itemType, itemId, out var matchableName, out var setEmbedding))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(matchableName))
+        {
+            return false;
+        }
+
+        var embeddingService = await _embeddingResolver.ResolveAsync(ct: ct).ConfigureAwait(false);
+        if (embeddingService is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var embedding = await embeddingService
+                .GenerateAsync(matchableName, cancellationToken: ct)
+                .ConfigureAwait(false);
+            setEmbedding(CloneEmbedding(embedding));
+            await PersistEmbeddingUpdatesAsync(ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to regenerate embedding for {ItemType} '{ItemId}'",
+                itemType,
+                itemId);
+            return false;
+        }
+    }
+
     // ── Private: Visibility Persistence ─────────────────────────────
 
     private async Task LoadVisibilityConfigAsync()
@@ -1003,6 +1227,58 @@ public sealed class EntityLocationService : IEntityLocationService
             entity.IncludeForAgent = config.EntityAgentMap.TryGetValue(entity.EntityId, out var agents)
                 ? new HashSet<string>(agents, StringComparer.OrdinalIgnoreCase)
                 : null; // null = visible to all
+        }
+    }
+
+    private bool TryResolveEmbeddingTarget(
+        string itemType,
+        string itemId,
+        out string matchableName,
+        out Action<Embedding<float>?> setEmbedding)
+    {
+        matchableName = string.Empty;
+        setEmbedding = _ => { };
+
+        if (string.IsNullOrWhiteSpace(itemType) || string.IsNullOrWhiteSpace(itemId))
+        {
+            return false;
+        }
+
+        var snap = _snapshot;
+        switch (itemType.Trim().ToLowerInvariant())
+        {
+            case "entity":
+                if (!snap.EntityById.TryGetValue(itemId, out var entity))
+                {
+                    return false;
+                }
+
+                matchableName = entity.FriendlyName;
+                setEmbedding = embedding => entity.NameEmbedding = embedding;
+                return true;
+
+            case "area":
+                if (!snap.AreaById.TryGetValue(itemId, out var area))
+                {
+                    return false;
+                }
+
+                matchableName = area.Name;
+                setEmbedding = embedding => area.NameEmbedding = embedding;
+                return true;
+
+            case "floor":
+                if (!snap.FloorById.TryGetValue(itemId, out var floor))
+                {
+                    return false;
+                }
+
+                matchableName = floor.Name;
+                setEmbedding = embedding => floor.NameEmbedding = embedding;
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/lucia.Agents/Services/EntityMatchNameFormatter.cs
+++ b/lucia.Agents/Services/EntityMatchNameFormatter.cs
@@ -1,0 +1,85 @@
+namespace lucia.Agents.Services;
+
+internal static class EntityMatchNameFormatter
+{
+    public static string ResolveName(
+        string? name,
+        IReadOnlyList<string>? aliases,
+        string fallbackId,
+        bool stripDomainFromId = false)
+    {
+        var normalizedName = NormalizeOptional(name);
+        if (normalizedName is not null)
+        {
+            return normalizedName;
+        }
+
+        if (aliases is not null)
+        {
+            foreach (var alias in aliases)
+            {
+                var normalizedAlias = NormalizeOptional(alias);
+                if (normalizedAlias is not null)
+                {
+                    return normalizedAlias;
+                }
+            }
+        }
+
+        var fallback = string.IsNullOrWhiteSpace(fallbackId) ? string.Empty : fallbackId.Trim();
+        if (stripDomainFromId)
+        {
+            var separatorIndex = fallback.IndexOf('.');
+            if (separatorIndex >= 0 && separatorIndex < fallback.Length - 1)
+            {
+                fallback = fallback[(separatorIndex + 1)..];
+            }
+        }
+
+        fallback = fallback.Replace('_', ' ');
+        var normalizedFallback = NormalizeOptional(fallback);
+        if (normalizedFallback is not null)
+        {
+            return normalizedFallback;
+        }
+
+        return string.IsNullOrWhiteSpace(fallbackId) ? "unknown" : fallbackId;
+    }
+
+    public static List<string> SanitizeAliases(IReadOnlyList<string>? aliases)
+    {
+        if (aliases is null || aliases.Count == 0)
+        {
+            return [];
+        }
+
+        var result = new List<string>(aliases.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var alias in aliases)
+        {
+            var normalizedAlias = NormalizeOptional(alias);
+            if (normalizedAlias is null)
+            {
+                continue;
+            }
+
+            if (seen.Add(normalizedAlias))
+            {
+                result.Add(normalizedAlias);
+            }
+        }
+
+        return result;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length == 0 ? null : string.Join(' ', parts);
+    }
+}

--- a/lucia.Tests/Services/EntityMatchNameFormatterTests.cs
+++ b/lucia.Tests/Services/EntityMatchNameFormatterTests.cs
@@ -1,0 +1,63 @@
+using lucia.Agents.Services;
+
+namespace lucia.Tests.Services;
+
+public class EntityMatchNameFormatterTests
+{
+    [Fact]
+    public void ResolveName_UsesPrimaryName_WhenProvided()
+    {
+        var result = EntityMatchNameFormatter.ResolveName(
+            "  Kitchen Lamp  ",
+            ["Alias Name"],
+            "light.kitchen_lamp",
+            stripDomainFromId: true);
+
+        Assert.Equal("Kitchen Lamp", result);
+    }
+
+    [Fact]
+    public void ResolveName_UsesFirstAlias_WhenNameMissing()
+    {
+        var result = EntityMatchNameFormatter.ResolveName(
+            null,
+            ["", "  Desk Lamp  "],
+            "light.office_lamp",
+            stripDomainFromId: true);
+
+        Assert.Equal("Desk Lamp", result);
+    }
+
+    [Fact]
+    public void ResolveName_UsesFormattedEntityId_WhenNameAndAliasesMissing()
+    {
+        var result = EntityMatchNameFormatter.ResolveName(
+            null,
+            [],
+            "light.diannas_lamp",
+            stripDomainFromId: true);
+
+        Assert.Equal("diannas lamp", result);
+    }
+
+    [Fact]
+    public void ResolveName_UsesFormattedIdWithoutDomainStrip_WhenRequested()
+    {
+        var result = EntityMatchNameFormatter.ResolveName(
+            null,
+            [],
+            "living_room",
+            stripDomainFromId: false);
+
+        Assert.Equal("living room", result);
+    }
+
+    [Fact]
+    public void SanitizeAliases_RemovesEmptyValuesAndDuplicates()
+    {
+        var result = EntityMatchNameFormatter.SanitizeAliases(
+            ["", "  ", "Desk Lamp", "desk lamp ", "Desk   Lamp", "Office"]);
+
+        Assert.Equal(["Desk Lamp", "Office"], result);
+    }
+}


### PR DESCRIPTION
## Summary
- add safe entity/floor/area name fallback (uid=1000(zackw) gid=1000(zackw) groups=1000(zackw),3(sys),90(network),950(ollama),955(docker),956(nopasswdlogin),979(rfkill),982(users),983(video),985(storage),989(lp),995(audio),998(wheel)-derived) to prevent empty embedding inputs
- move entity-location embedding generation to throttled background batch processing with retries
- add embedding progress snapshot API + live SSE stream
- add dashboard live progress bar and missing-embedding counts without manual refresh
- add per-item embedding evict/regenerate controls and update 1.1.0 release notes

## Validation
- dotnet build lucia.AgentHost
- dotnet test lucia.Tests --filter EntityMatchNameFormatterTests
- npm run build --silent (lucia-dashboard)
