### PR TITLE
fix: prevent presence refresh duplicate-key crash

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -110,6 +110,7 @@
 - **HACS validation workflow failure** — Corrected CI step order to ensure repository content is present.
 - **Startup embedding failures from blank input** — Prevented invalid embedding calls caused by empty match names.
 - **Embedding request bursts during cache reloads** — Moved generation to throttled background batching to reduce provider rate-limit pressure.
+- **Presence sensor refresh duplicate-key crashes** — Fixed MongoDB duplicate key failures on re-scan by deduplicating auto-detected sensor IDs and skipping IDs already reserved by user overrides (issue #41).
 
 ## 🧪 Testing
 

--- a/lucia.Agents/DataStores/MongoPresenceSensorRepository.cs
+++ b/lucia.Agents/DataStores/MongoPresenceSensorRepository.cs
@@ -54,7 +54,24 @@ public sealed class MongoPresenceSensorRepository : IPresenceSensorRepository
 
         if (autoDetected.Count > 0)
         {
-            await _mappings.InsertManyAsync(autoDetected, cancellationToken: ct).ConfigureAwait(false);
+            // Preserve user overrides that may already own the same entity IDs.
+            var existingMappings = await GetAllMappingsAsync(ct).ConfigureAwait(false);
+            var reservedEntityIds = existingMappings
+                .Select(m => m.EntityId)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var filteredMappings = autoDetected
+                .GroupBy(m => m.EntityId, StringComparer.OrdinalIgnoreCase)
+                .Select(static group => group
+                    .OrderByDescending(mapping => mapping.Confidence)
+                    .First())
+                .Where(mapping => !reservedEntityIds.Contains(mapping.EntityId))
+                .ToList();
+
+            if (filteredMappings.Count > 0)
+            {
+                await _mappings.InsertManyAsync(filteredMappings, cancellationToken: ct).ConfigureAwait(false);
+            }
         }
     }
 

--- a/lucia.Tests/Presence/MongoPresenceSensorRepositoryTests.cs
+++ b/lucia.Tests/Presence/MongoPresenceSensorRepositoryTests.cs
@@ -22,6 +22,10 @@ public sealed class MongoPresenceSensorRepositoryTests
         A.CallTo(() => _database.GetCollection<PresenceSensorMapping>("presence_sensor_mappings", null))
             .Returns(_mappingsCollection);
         A.CallTo(() => _mappingsCollection.Indexes).Returns(_indexManager);
+        A.CallTo(() => _mappingsCollection.FindAsync(
+            A<FilterDefinition<PresenceSensorMapping>>._,
+            A<FindOptions<PresenceSensorMapping, PresenceSensorMapping>>._,
+            A<CancellationToken>._)).Returns(CreateCursor([]));
 
         _repository = new MongoPresenceSensorRepository(_mongoClient);
     }
@@ -42,10 +46,7 @@ public sealed class MongoPresenceSensorRepositoryTests
             new() { EntityId = "binary_sensor.office_presence", AreaId = "office", Confidence = PresenceConfidence.High },
         };
 
-        var cursor = A.Fake<IAsyncCursor<PresenceSensorMapping>>();
-        A.CallTo(() => cursor.MoveNextAsync(A<CancellationToken>._))
-            .ReturnsNextFromSequence(true, false);
-        A.CallTo(() => cursor.Current).Returns(expected);
+        var cursor = CreateCursor(expected);
 
         A.CallTo(() => _mappingsCollection.FindAsync(
             A<FilterDefinition<PresenceSensorMapping>>._,
@@ -94,6 +95,76 @@ public sealed class MongoPresenceSensorRepositoryTests
     }
 
     [Fact]
+    public async Task ReplaceAutoDetectedMappingsAsync_SkipsEntitiesOwnedByUserOverride()
+    {
+        A.CallTo(() => _mappingsCollection.FindAsync(
+            A<FilterDefinition<PresenceSensorMapping>>._,
+            A<FindOptions<PresenceSensorMapping, PresenceSensorMapping>>._,
+            A<CancellationToken>._)).Returns(CreateCursor([
+                new PresenceSensorMapping
+                {
+                    EntityId = "binary_sensor.kitchen_presence",
+                    AreaId = "kitchen",
+                    IsUserOverride = true,
+                    Confidence = PresenceConfidence.High
+                }
+            ]));
+
+        await _repository.ReplaceAutoDetectedMappingsAsync([
+            new PresenceSensorMapping
+            {
+                EntityId = "binary_sensor.kitchen_presence",
+                AreaId = "kitchen",
+                IsUserOverride = false,
+                Confidence = PresenceConfidence.High
+            },
+            new PresenceSensorMapping
+            {
+                EntityId = "binary_sensor.office_presence",
+                AreaId = "office",
+                IsUserOverride = false,
+                Confidence = PresenceConfidence.Medium
+            }
+        ]);
+
+        A.CallTo(() => _mappingsCollection.InsertManyAsync(
+            A<IEnumerable<PresenceSensorMapping>>.That.Matches(mappings =>
+                mappings.Count() == 1
+                && mappings.Single().EntityId == "binary_sensor.office_presence"),
+            A<InsertManyOptions>._,
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task ReplaceAutoDetectedMappingsAsync_DeduplicatesByEntityId()
+    {
+        await _repository.ReplaceAutoDetectedMappingsAsync([
+            new PresenceSensorMapping
+            {
+                EntityId = "binary_sensor.office_presence",
+                AreaId = "office",
+                IsUserOverride = false,
+                Confidence = PresenceConfidence.Medium
+            },
+            new PresenceSensorMapping
+            {
+                EntityId = "binary_sensor.office_presence",
+                AreaId = "office",
+                IsUserOverride = false,
+                Confidence = PresenceConfidence.High
+            }
+        ]);
+
+        A.CallTo(() => _mappingsCollection.InsertManyAsync(
+            A<IEnumerable<PresenceSensorMapping>>.That.Matches(mappings =>
+                mappings.Count() == 1
+                && mappings.Single().EntityId == "binary_sensor.office_presence"
+                && mappings.Single().Confidence == PresenceConfidence.High),
+            A<InsertManyOptions>._,
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
     public async Task UpsertMappingAsync_CallsReplaceOneWithUpsert()
     {
         var mapping = new PresenceSensorMapping
@@ -121,5 +192,15 @@ public sealed class MongoPresenceSensorRepositoryTests
         A.CallTo(() => _mappingsCollection.DeleteOneAsync(
             A<FilterDefinition<PresenceSensorMapping>>._,
             A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    private static IAsyncCursor<PresenceSensorMapping> CreateCursor(IEnumerable<PresenceSensorMapping> mappings)
+    {
+        var cursor = A.Fake<IAsyncCursor<PresenceSensorMapping>>();
+        var buffered = mappings.ToList();
+        A.CallTo(() => cursor.MoveNextAsync(A<CancellationToken>._))
+            .ReturnsNextFromSequence(true, false);
+        A.CallTo(() => cursor.Current).Returns(buffered);
+        return cursor;
     }
 }


### PR DESCRIPTION
## Summary
- fix Mongo duplicate key failures during presence sensor refresh by deduplicating auto-detected mappings and skipping IDs already reserved by user overrides
- add repository regression tests for duplicate auto-detected IDs and user-override collisions
- document the issue #41 fix in the 1.1.0 release notes

## Validation
- dotnet test lucia.Tests/lucia.Tests.csproj --filter "FullyQualifiedName~Presence"

Closes #41