### PR TITLE
fix: resolve TS2339 build error in PluginsPage tab union type

### DIFF
--- a/lucia-dashboard/src/pages/PluginsPage.tsx
+++ b/lucia-dashboard/src/pages/PluginsPage.tsx
@@ -159,7 +159,7 @@ export default function PluginsPage() {
         {(
           [
             { id: 'installed' as Tab, label: 'Installed', icon: Puzzle, count: installed.length },
-            { id: 'config' as Tab, label: 'Configuration', icon: SlidersHorizontal },
+            { id: 'config' as Tab, label: 'Configuration', icon: SlidersHorizontal, count: undefined },
             { id: 'store' as Tab, label: 'Store', icon: Store, count: available.length },
           ] as const
         ).map(({ id, label, icon: Icon, count }) => (


### PR DESCRIPTION
## Problem

`PluginsPage.tsx` failed to build with:

```
TS2339: Property 'count' does not exist on type '{ readonly id: Tab; readonly label: "Installed"; ... } | { ... } | { ... }'.
```

The `as const` tuple created a discriminated union where the "Configuration" tab entry lacked a `count` property, causing TypeScript to reject the destructure on line 165.

## Fix

Added `count: undefined` to the Configuration tab entry so all union members share the same shape. The existing `count !== undefined` guard at line 177 already handles this correctly.

## Verification

- `npx tsc --noEmit` passes clean.