### PR TITLE
fix(plugins): switch Brave Search to LLM Context API

### DIFF
--- a/lucia-plugins.json
+++ b/lucia-plugins.json
@@ -13,7 +13,7 @@
       "id": "brave-search",
       "name": "Brave Search",
       "description": "Web search skill using the Brave Search API for privacy-respecting search.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "path": "plugins/brave-search"
     },
     {

--- a/lucia.Tests/BraveSearchWebSearchSkillTests.cs
+++ b/lucia.Tests/BraveSearchWebSearchSkillTests.cs
@@ -9,31 +9,48 @@ namespace lucia.Tests;
 /// <summary>
 /// Tests for the Brave Search web search skill HTTP integration.
 /// Since the skill is loaded via Roslyn script, we test the HTTP + JSON
-/// contract that the plugin relies on.
+/// contract that the plugin relies on (Brave LLM Context API).
 /// </summary>
 public sealed class BraveSearchWebSearchSkillTests
 {
     private readonly ILogger _logger = A.Fake<ILogger>();
 
     [Fact]
-    public async Task WebSearch_SuccessfulResponse_ReturnsFormattedResults()
+    public async Task WebSearch_SuccessfulResponse_DeserializesAndValidatesRequest()
     {
         // Arrange
         var responseJson = """
         {
-            "web": {
-                "results": [
+            "grounding": {
+                "generic": [
                     {
-                        "title": "Test Result One",
                         "url": "https://example.com/one",
-                        "description": "Description of the first result."
+                        "title": "Test Result One",
+                        "snippets": [
+                            "First relevant text chunk from the page.",
+                            "Second relevant passage from the same page."
+                        ]
                     },
                     {
-                        "title": "Test Result Two",
                         "url": "https://example.com/two",
-                        "description": "Description of the second result."
+                        "title": "Test Result Two",
+                        "snippets": [
+                            "Content extracted from the second source."
+                        ]
                     }
                 ]
+            },
+            "sources": {
+                "https://example.com/one": {
+                    "title": "Test Result One",
+                    "hostname": "example.com",
+                    "age": ["Monday, January 15, 2024", "2024-01-15", "380 days ago"]
+                },
+                "https://example.com/two": {
+                    "title": "Test Result Two",
+                    "hostname": "example.com",
+                    "age": null
+                }
             }
         }
         """;
@@ -52,27 +69,28 @@ public sealed class BraveSearchWebSearchSkillTests
         httpClient.DefaultRequestHeaders.Add("X-Subscription-Token", "test-api-key");
         httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
 
-        var factory = A.Fake<IHttpClientFactory>();
-        A.CallTo(() => factory.CreateClient("BraveSearch")).Returns(httpClient);
-
         // Act
-        var searchUrl = $"https://api.search.brave.com/res/v1/web/search?q={Uri.EscapeDataString("test query")}&count=8";
+        var searchUrl = $"https://api.search.brave.com/res/v1/llm/context?q={Uri.EscapeDataString("test query")}&count=8&maximum_number_of_tokens=8192";
         var response = await httpClient.GetAsync(searchUrl);
         var json = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<BraveSearchResponseDto>(json);
+        var result = JsonSerializer.Deserialize<BraveLlmContextResponseDto>(json);
 
         // Assert
-        Assert.NotNull(result?.Web?.Results);
-        Assert.Equal(2, result.Web.Results.Count);
-        Assert.Equal("Test Result One", result.Web.Results[0].Title);
-        Assert.Equal("https://example.com/one", result.Web.Results[0].Url);
-        Assert.Equal("Description of the first result.", result.Web.Results[0].Description);
-        Assert.Equal("Test Result Two", result.Web.Results[1].Title);
+        Assert.NotNull(result?.Grounding?.Generic);
+        Assert.Equal(2, result.Grounding.Generic.Count);
+        Assert.Equal("Test Result One", result.Grounding.Generic[0].Title);
+        Assert.Equal("https://example.com/one", result.Grounding.Generic[0].Url);
+        Assert.Equal(2, result.Grounding.Generic[0].Snippets.Count);
+        Assert.Equal("First relevant text chunk from the page.", result.Grounding.Generic[0].Snippets[0]);
+        Assert.Equal("Test Result Two", result.Grounding.Generic[1].Title);
+        Assert.Single(result.Grounding.Generic[1].Snippets);
 
-        // Verify request was sent to correct URL
+        // Verify request was sent to correct LLM Context API URL
         Assert.NotNull(capturedRequest);
-        Assert.Contains("q=test", capturedRequest.RequestUri!.AbsoluteUri);
+        Assert.Contains("/v1/llm/context", capturedRequest.RequestUri!.AbsoluteUri);
+        Assert.Contains("q=test", capturedRequest.RequestUri.AbsoluteUri);
         Assert.Contains("count=8", capturedRequest.RequestUri.AbsoluteUri);
+        Assert.Contains("maximum_number_of_tokens=8192", capturedRequest.RequestUri.AbsoluteUri);
 
         // Verify auth header
         Assert.Contains("test-api-key",
@@ -80,13 +98,14 @@ public sealed class BraveSearchWebSearchSkillTests
     }
 
     [Fact]
-    public async Task WebSearch_EmptyResults_ReturnsEmptyList()
+    public async Task WebSearch_EmptyGrounding_ReturnsEmptyList()
     {
         var responseJson = """
         {
-            "web": {
-                "results": []
-            }
+            "grounding": {
+                "generic": []
+            },
+            "sources": {}
         }
         """;
 
@@ -97,18 +116,18 @@ public sealed class BraveSearchWebSearchSkillTests
             });
 
         var httpClient = new HttpClient(handler);
-        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/web/search?q=nothing&count=8");
+        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/llm/context?q=nothing&count=8&maximum_number_of_tokens=8192");
         var json = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<BraveSearchResponseDto>(json);
+        var result = JsonSerializer.Deserialize<BraveLlmContextResponseDto>(json);
 
-        Assert.NotNull(result?.Web?.Results);
-        Assert.Empty(result.Web.Results);
+        Assert.NotNull(result?.Grounding?.Generic);
+        Assert.Empty(result.Grounding.Generic);
     }
 
     [Fact]
-    public async Task WebSearch_NullWebField_HandlesGracefully()
+    public async Task WebSearch_NullGroundingField_HandlesGracefully()
     {
-        var responseJson = """{ "type": ["web"] }""";
+        var responseJson = """{ "sources": {} }""";
 
         var handler = new FakeHttpMessageHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)
@@ -117,15 +136,15 @@ public sealed class BraveSearchWebSearchSkillTests
             });
 
         var httpClient = new HttpClient(handler);
-        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/web/search?q=test&count=8");
+        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/llm/context?q=test&count=8&maximum_number_of_tokens=8192");
         var json = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<BraveSearchResponseDto>(json);
+        var result = JsonSerializer.Deserialize<BraveLlmContextResponseDto>(json);
 
-        Assert.Null(result?.Web);
+        Assert.Null(result?.Grounding);
     }
 
     [Fact]
-    public async Task WebSearch_ApiError_ThrowsHttpRequestException()
+    public async Task WebSearch_ApiError_ReturnsUnauthorizedStatus()
     {
         var handler = new FakeHttpMessageHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.Unauthorized)
@@ -134,23 +153,31 @@ public sealed class BraveSearchWebSearchSkillTests
             });
 
         var httpClient = new HttpClient(handler);
-        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/web/search?q=test&count=8");
+        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/llm/context?q=test&count=8&maximum_number_of_tokens=8192");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
-    public async Task WebSearch_ResultWithMissingDescription_DeserializesWithNull()
+    public async Task WebSearch_GroundingItemWithEmptySnippets_DeserializesCorrectly()
     {
         var responseJson = """
         {
-            "web": {
-                "results": [
+            "grounding": {
+                "generic": [
                     {
-                        "title": "No Description Result",
-                        "url": "https://example.com/no-desc"
+                        "url": "https://example.com/no-snippets",
+                        "title": "No Snippets Result",
+                        "snippets": []
                     }
                 ]
+            },
+            "sources": {
+                "https://example.com/no-snippets": {
+                    "title": "No Snippets Result",
+                    "hostname": "example.com",
+                    "age": null
+                }
             }
         }
         """;
@@ -162,41 +189,100 @@ public sealed class BraveSearchWebSearchSkillTests
             });
 
         var httpClient = new HttpClient(handler);
-        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/web/search?q=test&count=8");
+        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/llm/context?q=test&count=8&maximum_number_of_tokens=8192");
         var json = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<BraveSearchResponseDto>(json);
+        var result = JsonSerializer.Deserialize<BraveLlmContextResponseDto>(json);
 
-        Assert.NotNull(result?.Web?.Results);
-        Assert.Single(result.Web.Results);
-        Assert.Equal("No Description Result", result.Web.Results[0].Title);
-        Assert.Null(result.Web.Results[0].Description);
+        Assert.NotNull(result?.Grounding?.Generic);
+        Assert.Single(result.Grounding.Generic);
+        Assert.Equal("No Snippets Result", result.Grounding.Generic[0].Title);
+        Assert.Empty(result.Grounding.Generic[0].Snippets);
+    }
+
+    [Fact]
+    public async Task WebSearch_SourceMetadata_DeserializesCorrectly()
+    {
+        var responseJson = """
+        {
+            "grounding": {
+                "generic": [
+                    {
+                        "url": "https://example.com/page",
+                        "title": "Example Page",
+                        "snippets": ["Some content from the page."]
+                    }
+                ]
+            },
+            "sources": {
+                "https://example.com/page": {
+                    "title": "Example Page",
+                    "hostname": "example.com",
+                    "age": ["Monday, January 15, 2024", "2024-01-15", "380 days ago"]
+                }
+            }
+        }
+        """;
+
+        var handler = new FakeHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json")
+            });
+
+        var httpClient = new HttpClient(handler);
+        var response = await httpClient.GetAsync("https://api.search.brave.com/res/v1/llm/context?q=test&count=8&maximum_number_of_tokens=8192");
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<BraveLlmContextResponseDto>(json);
+
+        Assert.NotNull(result?.Sources);
+        Assert.True(result.Sources.ContainsKey("https://example.com/page"));
+        var source = result.Sources["https://example.com/page"];
+        Assert.Equal("Example Page", source.Title);
+        Assert.Equal("example.com", source.Hostname);
+        Assert.NotNull(source.Age);
+        Assert.Equal(3, source.Age.Count);
     }
 
     /// <summary>
-    /// Local DTO mirroring the Brave Search plugin's response types.
+    /// Local DTOs mirroring the Brave LLM Context API response types.
     /// These validate the JSON contract the plugin relies on.
     /// </summary>
-    private sealed class BraveSearchResponseDto
+    private sealed class BraveLlmContextResponseDto
     {
-        [JsonPropertyName("web")]
-        public BraveWebResultsDto? Web { get; set; }
+        [JsonPropertyName("grounding")]
+        public BraveLlmGroundingDto? Grounding { get; set; }
+
+        [JsonPropertyName("sources")]
+        public Dictionary<string, BraveLlmSourceDto>? Sources { get; set; }
     }
 
-    private sealed class BraveWebResultsDto
+    private sealed class BraveLlmGroundingDto
     {
-        [JsonPropertyName("results")]
-        public List<BraveWebResultDto> Results { get; set; } = [];
+        [JsonPropertyName("generic")]
+        public List<BraveLlmGroundingItemDto> Generic { get; set; } = [];
     }
 
-    private sealed class BraveWebResultDto
+    private sealed class BraveLlmGroundingItemDto
+    {
+        [JsonPropertyName("url")]
+        public string Url { get; set; } = "";
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = "";
+
+        [JsonPropertyName("snippets")]
+        public List<string> Snippets { get; set; } = [];
+    }
+
+    private sealed class BraveLlmSourceDto
     {
         [JsonPropertyName("title")]
         public string Title { get; set; } = "";
 
-        [JsonPropertyName("url")]
-        public string Url { get; set; } = "";
+        [JsonPropertyName("hostname")]
+        public string Hostname { get; set; } = "";
 
-        [JsonPropertyName("description")]
-        public string? Description { get; set; }
+        [JsonPropertyName("age")]
+        public List<string>? Age { get; set; }
     }
 }

--- a/plugins/brave-search/plugin.cs
+++ b/plugins/brave-search/plugin.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -16,8 +17,8 @@ public sealed class BraveSearchWebSearchSkill : IWebSearchSkill
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger _logger;
 
-    private static readonly ActivitySource ActivitySource = new("Lucia.Skills.WebSearch.BraveSearch", "1.0.0");
-    private static readonly Meter Meter = new("Lucia.Skills.WebSearch.BraveSearch", "1.0.0");
+    private static readonly ActivitySource ActivitySource = new("Lucia.Skills.WebSearch.BraveSearch", "1.1.0");
+    private static readonly Meter Meter = new("Lucia.Skills.WebSearch.BraveSearch", "1.1.0");
     private static readonly Counter<long> SearchRequests = Meter.CreateCounter<long>("websearch.brave.requests", "{count}", "Number of Brave web search requests.");
     private static readonly Counter<long> SearchFailures = Meter.CreateCounter<long>("websearch.brave.failures", "{count}", "Number of failed Brave web searches.");
     private static readonly Histogram<double> SearchDurationMs = Meter.CreateHistogram<double>("websearch.brave.duration", "ms", "Duration of Brave web search operations.");
@@ -36,7 +37,7 @@ public sealed class BraveSearchWebSearchSkill : IWebSearchSkill
         return Task.CompletedTask;
     }
 
-    [Description("Search the web for current information. Use when the user asks about recent events, news, or facts that may have changed. Returns title, URL, and snippet for each result.")]
+    [Description("Search the web for current information using the Brave LLM Context API. Returns pre-extracted, relevance-scored web content optimized for LLM consumption including text chunks, tables, and code blocks from source pages.")]
     public async Task<string> WebSearchAsync(
         [Description("The search query (e.g. 'latest news about renewable energy', 'weather in Paris today')")] string query,
         CancellationToken cancellationToken = default)
@@ -48,16 +49,16 @@ public sealed class BraveSearchWebSearchSkill : IWebSearchSkill
 
         try
         {
-            var searchUrl = $"https://api.search.brave.com/res/v1/web/search?q={Uri.EscapeDataString(query)}&count=8";
+            var searchUrl = $"https://api.search.brave.com/res/v1/llm/context?q={Uri.EscapeDataString(query)}&count=8&maximum_number_of_tokens=8192";
             var client = _httpClientFactory.CreateClient("BraveSearch");
             var response = await client.GetAsync(searchUrl, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            var result = JsonSerializer.Deserialize<BraveSearchResponse>(json);
-            var webResults = result?.Web?.Results;
+            var result = JsonSerializer.Deserialize<BraveLlmContextResponse>(json);
+            var groundingItems = result?.Grounding?.Generic;
 
-            if (webResults is null || webResults.Count == 0)
+            if (groundingItems is null || groundingItems.Count == 0)
             {
                 RecordDuration(start);
                 activity?.SetStatus(ActivityStatusCode.Ok);
@@ -65,25 +66,27 @@ public sealed class BraveSearchWebSearchSkill : IWebSearchSkill
             }
 
             var sb = new StringBuilder();
-            sb.AppendLine($"Found {webResults.Count} result(s) for \"{query}\":");
-            foreach (var r in webResults.Take(8))
+            sb.AppendLine($"Found context from {groundingItems.Count} source(s) for \"{query}\":");
+            foreach (var item in groundingItems.Take(8))
             {
                 sb.AppendLine();
-                sb.AppendLine($"**{r.Title}**");
-                sb.AppendLine(r.Url);
-                if (!string.IsNullOrWhiteSpace(r.Description))
-                    sb.AppendLine(r.Description);
+                sb.AppendLine($"**{item.Title}**");
+                sb.AppendLine(item.Url);
+                foreach (var snippet in item.Snippets ?? [])
+                {
+                    sb.AppendLine(snippet);
+                }
             }
 
             var ms = RecordDuration(start);
             activity?.SetStatus(ActivityStatusCode.Ok);
-            _logger.LogDebug("Brave search completed in {Ms}ms, {Count} results.", ms, webResults.Count);
+            _logger.LogDebug("Brave LLM Context search completed in {Ms}ms, {Count} sources.", ms, groundingItems.Count);
             return sb.ToString().TrimEnd();
         }
         catch (Exception ex)
         {
             SearchFailures.Add(1);
-            _logger.LogWarning(ex, "Brave search failed for query: {Query}.", query);
+            _logger.LogWarning(ex, "Brave LLM Context search failed for query: {Query}.", query);
             return $"Web search failed: {ex.Message}";
         }
     }
@@ -96,28 +99,43 @@ public sealed class BraveSearchWebSearchSkill : IWebSearchSkill
     }
 }
 
-public sealed class BraveSearchResponse
+public sealed class BraveLlmContextResponse
 {
-    [JsonPropertyName("web")]
-    public BraveWebResults? Web { get; set; }
+    [JsonPropertyName("grounding")]
+    public BraveLlmGrounding? Grounding { get; set; }
+
+    [JsonPropertyName("sources")]
+    public Dictionary<string, BraveLlmSource>? Sources { get; set; }
 }
 
-public sealed class BraveWebResults
+public sealed class BraveLlmGrounding
 {
-    [JsonPropertyName("results")]
-    public List<BraveWebResult> Results { get; set; } = [];
+    [JsonPropertyName("generic")]
+    public List<BraveLlmGroundingItem> Generic { get; set; } = [];
 }
 
-public sealed class BraveWebResult
+public sealed class BraveLlmGroundingItem
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("snippets")]
+    public List<string> Snippets { get; set; } = [];
+}
+
+public sealed class BraveLlmSource
 {
     [JsonPropertyName("title")]
     public string Title { get; set; } = "";
 
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = "";
+    [JsonPropertyName("hostname")]
+    public string Hostname { get; set; } = "";
 
-    [JsonPropertyName("description")]
-    public string? Description { get; set; }
+    [JsonPropertyName("age")]
+    public List<string>? Age { get; set; }
 }
 
 public class BraveSearchPlugin : ILuciaPlugin


### PR DESCRIPTION
## Summary

Switches the Brave Search plugin from the raw Web Search API (`/v1/web/search`) to the **LLM Context API** (`/v1/llm/context`).

### Changes
- Updated endpoint URL to `/v1/llm/context`
- Added `maximum_number_of_tokens=8192` parameter
- Replaced response DTOs (`BraveSearchResponse` → `BraveLlmContextResponse`, etc.) to match the new schema
- Updated result formatting to output grounding snippets with source attribution
- Rewrote all 5 existing tests + added new `SourceMetadata_DeserializesCorrectly` test (all 6 pass)

Closes #70