### PR TITLE
fix(build): allow SDK feature-band roll-forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.103",
-    "rollForward": "latestPatch",
+    "rollForward": "latestFeature",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
This pull request updates the .NET SDK configuration in the `global.json` file to allow roll-forward to the latest feature version instead of only the latest patch. This change enables the project to use newer feature releases of the SDK, which may include new capabilities and improvements.

SDK configuration update:

* Changed the `rollForward` setting in `global.json` from `"latestPatch"` to `"latestFeature"`, allowing the project to roll forward to newer feature versions of the .NET SDK.