### PR TITLE
feat(conversation): strip speaker identification tag from voice trans…

### DIFF
--- a/lucia.AgentHost/Conversation/ContextReconstructor.cs
+++ b/lucia.AgentHost/Conversation/ContextReconstructor.cs
@@ -54,6 +54,10 @@ public sealed class ContextReconstructor
             .Replace("{deviceArea}", context.DeviceArea ?? "unknown")
             .Replace("{deviceType}", context.DeviceType ?? "voice_assistant");
 
-        return $"{prompt}\n\nUser: {request.Text}";
+        var speakerLine = context.SpeakerId is not null
+            ? $"\n[Speaker: {context.SpeakerId}]"
+            : string.Empty;
+
+        return $"{prompt}{speakerLine}\n\nUser: {request.Text}";
     }
 }

--- a/lucia.AgentHost/Conversation/ConversationCommandProcessor.cs
+++ b/lucia.AgentHost/Conversation/ConversationCommandProcessor.cs
@@ -55,21 +55,28 @@ public sealed partial class ConversationCommandProcessor
 
         LogProcessingStart(request.Text, request.Context.DeviceArea);
 
+        // Strip optional speaker identification tag from voice platform
+        var (speakerId, cleanText) = SpeakerTagParser.Parse(request.Text);
+        var context = speakerId is not null
+            ? request.Context with { SpeakerId = speakerId }
+            : request.Context;
+        var cleanRequest = request with { Text = cleanText, Context = context };
+
         // Ensure a stable conversationId for multi-turn continuity
-        var conversationId = request.Context.ConversationId
+        var conversationId = context.ConversationId
             ?? Guid.NewGuid().ToString("N");
 
-        // Step 1: Try command pattern matching
-        var routeResult = await _commandRouter.RouteAsync(request.Text, ct).ConfigureAwait(false);
+        // Step 1: Try command pattern matching (on clean text, without speaker tag)
+        var routeResult = await _commandRouter.RouteAsync(cleanText, ct).ConfigureAwait(false);
 
         if (routeResult.IsMatch && routeResult.MatchedPattern is not null)
         {
-            return await HandleCommandMatchAsync(request, routeResult, conversationId, activity, sw, ct)
+            return await HandleCommandMatchAsync(cleanRequest, routeResult, conversationId, activity, sw, ct)
                 .ConfigureAwait(false);
         }
 
-        // Step 2: No match — fall back to LLM
-        return await HandleLlmFallbackAsync(request, conversationId, activity, sw, ct)
+        // Step 2: No match — fall back to LLM (with clean text + speaker in context)
+        return await HandleLlmFallbackAsync(cleanRequest, conversationId, activity, sw, ct)
             .ConfigureAwait(false);
     }
 
@@ -86,6 +93,8 @@ public sealed partial class ConversationCommandProcessor
         activity?.SetTag("conversation.skill_id", pattern.SkillId);
         activity?.SetTag("conversation.action", pattern.Action);
         activity?.SetTag("conversation.confidence", routeResult.Confidence);
+        if (request.Context.SpeakerId is not null)
+            activity?.SetTag("conversation.speaker_id", request.Context.SpeakerId);
 
         LogCommandMatch(pattern.SkillId, pattern.Action, routeResult.Confidence);
 

--- a/lucia.AgentHost/Conversation/Models/ConversationContext.cs
+++ b/lucia.AgentHost/Conversation/Models/ConversationContext.cs
@@ -27,6 +27,13 @@ public sealed record ConversationContext
     [JsonPropertyName("userId")]
     public string? UserId { get; init; }
 
+    /// <summary>
+    /// Speaker name identified by the Wyoming voice platform's speaker verification.
+    /// Populated server-side by stripping the <c>&lt;Name /&gt;</c> tag from the transcript.
+    /// </summary>
+    [JsonPropertyName("speakerId")]
+    public string? SpeakerId { get; init; }
+
     [JsonPropertyName("location")]
     public string? Location { get; init; }
 }

--- a/lucia.AgentHost/Conversation/SpeakerTagParser.cs
+++ b/lucia.AgentHost/Conversation/SpeakerTagParser.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+
+namespace lucia.AgentHost.Conversation;
+
+/// <summary>
+/// Extracts an optional speaker identification tag from the beginning of a transcript.
+/// The Wyoming voice platform prefixes transcripts with <c>&lt;SpeakerName /&gt;</c>
+/// when speaker verification identifies the user.
+/// </summary>
+public static partial class SpeakerTagParser
+{
+    /// <summary>
+    /// Strips a leading <c>&lt;Name /&gt;</c> tag from <paramref name="text"/>,
+    /// returning the speaker name and the remaining clean text.
+    /// Returns <c>null</c> speaker when no tag is present.
+    /// </summary>
+    public static (string? SpeakerId, string CleanText) Parse(string text)
+    {
+        var match = SpeakerTagPattern().Match(text);
+        if (!match.Success)
+            return (null, text);
+
+        var speakerId = match.Groups[1].Value.Trim();
+        var cleanText = text[match.Length..].TrimStart();
+        return (speakerId, cleanText);
+    }
+
+    // Matches: <Name /> at the start of string, allowing whitespace variations
+    [GeneratedRegex(@"^<\s*([^/<>]+?)\s*/>", RegexOptions.None, matchTimeoutMilliseconds: 500)]
+    private static partial Regex SpeakerTagPattern();
+}

--- a/lucia.Tests/Conversation/SpeakerTagParserTests.cs
+++ b/lucia.Tests/Conversation/SpeakerTagParserTests.cs
@@ -1,0 +1,61 @@
+using lucia.AgentHost.Conversation;
+
+namespace lucia.Tests.Conversation;
+
+public sealed class SpeakerTagParserTests
+{
+    [Fact]
+    public void Parse_WithSpeakerTag_ExtractsSpeakerAndCleanText()
+    {
+        var (speaker, text) = SpeakerTagParser.Parse("<Zack />Turn on the office lights");
+
+        Assert.Equal("Zack", speaker);
+        Assert.Equal("Turn on the office lights", text);
+    }
+
+    [Fact]
+    public void Parse_WithNoTag_ReturnsNullSpeakerAndOriginalText()
+    {
+        var (speaker, text) = SpeakerTagParser.Parse("Turn on the office lights");
+
+        Assert.Null(speaker);
+        Assert.Equal("Turn on the office lights", text);
+    }
+
+    [Fact]
+    public void Parse_WithSpacesInTag_TrimsSpeakerName()
+    {
+        var (speaker, text) = SpeakerTagParser.Parse("< Sarah />Set the thermostat to 72");
+
+        Assert.Equal("Sarah", speaker);
+        Assert.Equal("Set the thermostat to 72", text);
+    }
+
+    [Fact]
+    public void Parse_WithMultiWordSpeaker_CapturesFullName()
+    {
+        var (speaker, text) = SpeakerTagParser.Parse("<John Smith />Make it warmer");
+
+        Assert.Equal("John Smith", speaker);
+        Assert.Equal("Make it warmer", text);
+    }
+
+    [Fact]
+    public void Parse_WithEmptyTextAfterTag_ReturnsEmptyCleanText()
+    {
+        var (speaker, text) = SpeakerTagParser.Parse("<Zack />");
+
+        Assert.Equal("Zack", speaker);
+        Assert.Equal("", text);
+    }
+
+    [Fact]
+    public void Parse_WithTagInMiddle_DoesNotMatch()
+    {
+        const string input = "Please <Zack />turn on lights";
+        var (speaker, text) = SpeakerTagParser.Parse(input);
+
+        Assert.Null(speaker);
+        Assert.Equal(input, text);
+    }
+}


### PR DESCRIPTION
This pull request adds support for extracting and handling speaker identification tags from transcripts generated by the Wyoming voice platform. It introduces a parser for the speaker tag, updates the conversation context to include speaker information, and ensures that downstream processing and logging incorporate the speaker when present.

Speaker tag extraction and handling:

* Added `SpeakerTagParser` utility to extract the speaker name from transcripts prefixed with `<SpeakerName />`, returning both the speaker and cleaned text.
* Updated `ConversationContext` to include a new `SpeakerId` property for storing the identified speaker.
* Modified `ConversationCommandProcessor.ProcessAsync` to parse and strip the speaker tag from incoming requests, updating context and text for downstream processing.

Integration with conversation processing and logging:

* Updated command pattern matching and LLM fallback to use the cleaned text and speaker-enriched context, ensuring consistent multi-turn conversation handling and accurate logging. [[1]](diffhunk://#diff-5afb48a9a18bb409f988953df3b67df919d535f4c894078d50edcd4bc49434c6R58-R79) [[2]](diffhunk://#diff-5afb48a9a18bb409f988953df3b67df919d535f4c894078d50edcd4bc49434c6R96-R97)
* Enhanced activity logging for command matches to include the speaker ID when available, improving traceability.

Prompt reconstruction:

* Modified `ContextReconstructor.Reconstruct` to include the speaker line in prompts when a speaker is identified, ensuring speaker information is visible in reconstructed conversation context.

Testing:

* Added comprehensive unit tests for `SpeakerTagParser` covering various tag formats, whitespace handling, multi-word names, and edge cases.