### PR TITLE
fix(deps): bump vite to 7.3.2+ to resolve 3 Dependabot CVEs

### DIFF
--- a/lucia-dashboard/package-lock.json
+++ b/lucia-dashboard/package-lock.json
@@ -32,7 +32,7 @@
         "playwright": "^1.58.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4011,9 +4011,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/lucia-dashboard/package.json
+++ b/lucia-dashboard/package.json
@@ -34,7 +34,7 @@
     "playwright": "^1.58.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.2"
   },
   "overrides": {
     "minimatch": "^10.2.3",


### PR DESCRIPTION
Resolves the 3 open Dependabot alerts (2 high, 1 moderate) for the ite npm package in `lucia-dashboard`, all patched by bumping vite **7.3.1 -> 7.3.2** (npm resolved to 7.3.3):

- [high] Arbitrary File Read via Dev Server WebSocket
- [high] `server.fs.deny` bypass with crafted query
- [medium] Path Traversal in Optimized Deps `.map` files

### Validation
- `npm run build` (`tsc -b && vite build`) passes - 1995 modules transformed, build succeeded.
- Pre-commit TypeScript type-check passes.
- Pre-existing eslint warnings/errors are unrelated to this bump (present on master).

### Why a fresh branch instead of Dependabot PR #117
PR #117 proposes the same bump but its CI fails because its **base is stale** (May 18, predating the .NET NuGetAudit package fixes already on master) - not a vite incompatibility. This branch is cut from current `master` so it builds clean.

Closes #199