### PR TITLE
fix(deps): align package versions with Aspire 13.4.2 transitives

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
        ══════════════════════════════════════════════════════════════ -->
   <PropertyGroup Label="Version Variables">
     <MicrosoftAgentsVersion>1.0.0-rc2</MicrosoftAgentsVersion>
-    <MicrosoftExtensionsAIVersion>10.5.0</MicrosoftExtensionsAIVersion>
-    <MicrosoftExtensionsVersion>10.0.7</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigVersion>10.0.7</MicrosoftExtensionsConfigVersion>
+    <MicrosoftExtensionsAIVersion>10.6.0</MicrosoftExtensionsAIVersion>
+    <MicrosoftExtensionsVersion>10.0.8</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigVersion>10.0.8</MicrosoftExtensionsConfigVersion>
     <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <XunitVersion>2.9.3</XunitVersion>
   </PropertyGroup>
@@ -19,25 +19,25 @@
   <ItemGroup Label="A2A Protocol">
     <PackageVersion Include="A2A" Version="1.0.0-preview" />
     <PackageVersion Include="A2A.AspNetCore" Version="1.0.0-preview" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.2" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
   </ItemGroup>
   <!-- ── .NET Aspire Hosting (AppHost orchestration) ──────────── -->
   <ItemGroup Label="Aspire Hosting">
     <PackageVersion Include="Aspire.Hosting.Azure.AIFoundry" Version="13.1.3-preview.1.26166.8" />
-    <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.OpenAI" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.CognitiveServices" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.OpenAI" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.2" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.0" />
   </ItemGroup>
   <!-- ── .NET Aspire Client Integrations (service projects) ───── -->
   <ItemGroup Label="Aspire Client Integrations">
-    <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="13.3.3-preview.1.26264.13" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="13.4.2-preview.1.26303.6" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.4.2" />
     <PackageVersion Include="Aspire.MongoDB.Driver.v3" Version="9.5.2" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.4.2" />
   </ItemGroup>
   <!-- ── Microsoft Agent Framework ────────────────────────────── -->
   <ItemGroup Label="Microsoft Agent Framework">
@@ -108,10 +108,10 @@
   <!-- ── Data & Infrastructure ────────────────────────────────── -->
   <ItemGroup Label="Data and Infrastructure">
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="System.Text.Json" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.12.8" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
   </ItemGroup>
   <!-- ── API Documentation ────────────────────────────────────── -->
   <ItemGroup Label="API Documentation">
@@ -148,7 +148,7 @@
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.23.2" />
     <PackageVersion Include="org.k2fsa.sherpa.onnx" Version="1.12.34" />
     <PackageVersion Include="GitHub.Copilot.SDK" Version="0.2.1-preview.1" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
   </ItemGroup>
@@ -157,7 +157,7 @@
     <PackageVersion Include="Makaretu.Dns.Multicast" Version="0.27.0" />
     <PackageVersion Include="NAudio" Version="2.3.0" />
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
-    <PackageVersion Include="SharpCompress" Version="0.48.1" />
+    <PackageVersion Include="SharpCompress" Version="1.0.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />

--- a/lucia.AppHost/lucia.AppHost.csproj
+++ b/lucia.AppHost/lucia.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.2">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PreviewFeatures>enable</PreviewFeatures>

--- a/lucia.Tests/Orchestration/AgentEvalTestBase.cs
+++ b/lucia.Tests/Orchestration/AgentEvalTestBase.cs
@@ -164,7 +164,7 @@ public abstract class AgentEvalTestBase
         tags.AddRange(additionalTags);
 
         await using var scenarioRun = await reportingConfig.CreateScenarioRunAsync(
-            $"{scenarioName}[{deploymentName}]",
+            BuildScenarioRunName(scenarioName, deploymentName),
             additionalTags: tags);
 
         // Pass latency context to evaluators.
@@ -212,7 +212,7 @@ public abstract class AgentEvalTestBase
         tags.AddRange(additionalTags);
 
         await using var scenarioRun = await reportingConfig.CreateScenarioRunAsync(
-            $"{scenarioName}[{deploymentName}]",
+            BuildScenarioRunName(scenarioName, deploymentName),
             additionalTags: tags);
 
         // Build evaluator contexts with captured tool definitions and latency
@@ -259,7 +259,7 @@ public abstract class AgentEvalTestBase
         tags.AddRange(additionalTags);
 
         await using var scenarioRun = await reportingConfig.CreateScenarioRunAsync(
-            $"{scenarioName}[{deploymentName}]",
+            BuildScenarioRunName(scenarioName, deploymentName),
             additionalTags: tags);
 
         var latencyContext = new LatencyEvaluatorContext(stopwatch.Elapsed);
@@ -327,7 +327,7 @@ public abstract class AgentEvalTestBase
         tags.AddRange(additionalTags);
 
         await using var scenarioRun = await reportingConfig.CreateScenarioRunAsync(
-            $"{scenarioName}[{deploymentName}]",
+            BuildScenarioRunName(scenarioName, deploymentName),
             additionalTags: tags);
 
         var contexts = new List<EvaluationContext>
@@ -555,4 +555,42 @@ public abstract class AgentEvalTestBase
         string.Join("; ", calls.Select(c =>
             $"{c.Name}({FormatArgKeys(c.Arguments)})"));
 
+    // ─── Scenario name formatting ────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a scenario-run identifier of the form
+    /// <c>{scenarioName}[{sanitizedDeploymentName}]</c>. The deployment name is
+    /// sanitized so that characters illegal in filesystem paths
+    /// (notably <c>:</c> for model ids like <c>gpt-oss:20b</c> on Windows)
+    /// don't break <see cref="DiskBasedReportingConfiguration"/> when it
+    /// materializes the scenario directory.
+    /// </summary>
+    private static string BuildScenarioRunName(string scenarioName, string deploymentName) =>
+        $"{scenarioName}[{SanitizePathSegment(deploymentName)}]";
+
+    private static readonly char[] s_extraInvalidPathChars = [':', '/', '\\', '*', '?', '"', '<', '>', '|'];
+
+    private static string SanitizePathSegment(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        // Combine the platform-invalid set (which on Linux is tiny) with a
+        // conservative cross-platform set so reports are portable.
+        var invalid = new HashSet<char>(Path.GetInvalidFileNameChars());
+        foreach (var c in s_extraInvalidPathChars)
+        {
+            invalid.Add(c);
+        }
+
+        var buffer = new char[value.Length];
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            buffer[i] = invalid.Contains(c) ? '_' : c;
+        }
+        return new string(buffer);
+    }
 }

--- a/lucia.Tests/Orchestration/EvalCredentialChecks.cs
+++ b/lucia.Tests/Orchestration/EvalCredentialChecks.cs
@@ -1,0 +1,35 @@
+namespace lucia.Tests.Orchestration;
+
+/// <summary>
+/// Helpers for inspecting eval test credential values such as API keys.
+/// Treats the angle-bracket placeholder convention used in committed
+/// <c>appsettings.json</c> (e.g. <c>&lt;YOUR_AZURE_OPENAI_API_KEY&gt;</c>)
+/// as "not configured" so eval tests skip cleanly when secrets have not
+/// been overridden via user secrets or environment variables.
+/// </summary>
+public static class EvalCredentialChecks
+{
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="value"/> is a non-empty
+    /// angle-bracket placeholder like <c>&lt;YOUR_KEY&gt;</c>. Empty values
+    /// return <c>false</c> — callers can treat them as "use the default
+    /// credential" rather than as a placeholder.
+    /// </summary>
+    public static bool IsPlaceholder(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length >= 2 && trimmed[0] == '<' && trimmed[^1] == '>';
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="value"/> is non-empty and not
+    /// an angle-bracket placeholder.
+    /// </summary>
+    public static bool IsUsable(string? value) =>
+        !string.IsNullOrWhiteSpace(value) && !IsPlaceholder(value);
+}

--- a/lucia.Tests/Orchestration/EvalTestFixture.cs
+++ b/lucia.Tests/Orchestration/EvalTestFixture.cs
@@ -285,6 +285,8 @@ public sealed class EvalTestFixture : IAsyncLifetime
     {
         var provider = model.Provider ?? EvalProviderType.AzureOpenAI;
 
+        SkipIfModelNotConfigured(model, provider);
+
         return provider switch
         {
             EvalProviderType.AzureOpenAI => AzureClient.GetChatClient(model.DeploymentName).AsIChatClient(),
@@ -292,6 +294,46 @@ public sealed class EvalTestFixture : IAsyncLifetime
             EvalProviderType.OpenAI => CreateOpenAIChatClient(model),
             _ => throw new NotSupportedException($"Provider type '{provider}' is not supported in eval tests.")
         };
+    }
+
+    /// <summary>
+    /// Throws <see cref="Xunit.SkipException"/> when the credentials required to
+    /// reach <paramref name="model"/> are missing or are still set to a committed
+    /// placeholder like <c>&lt;YOUR_AZURE_OPENAI_API_KEY&gt;</c>. Ollama does not
+    /// require credentials; tests against an unreachable local endpoint will
+    /// surface as connection errors instead of skips.
+    /// </summary>
+    private void SkipIfModelNotConfigured(EvalModelConfig model, EvalProviderType provider)
+    {
+        switch (provider)
+        {
+            case EvalProviderType.OpenAI:
+                if (!EvalCredentialChecks.IsUsable(model.ApiKey))
+                {
+                    throw new Xunit.SkipException(
+                        $"OpenAI model '{model.DeploymentName}' has no usable API key. " +
+                        "Set EvalConfiguration:Models[*]:ApiKey (or the matching environment variable) " +
+                        "to a real key to run this test.");
+                }
+                break;
+
+            case EvalProviderType.AzureOpenAI:
+                // The shared AzureOpenAIClient was built from Configuration.AzureOpenAI.ApiKey
+                // (or AzureCliCredential when the key is null/empty). A placeholder value will
+                // 401 at the first request; skip instead.
+                if (EvalCredentialChecks.IsPlaceholder(Configuration.AzureOpenAI.ApiKey))
+                {
+                    throw new Xunit.SkipException(
+                        $"Azure OpenAI model '{model.DeploymentName}' cannot be reached: " +
+                        "EvalConfiguration:AzureOpenAI:ApiKey is still set to a placeholder. " +
+                        "Replace it with a real key, or unset it to use AzureCliCredential after `az login`.");
+                }
+                break;
+
+            case EvalProviderType.Ollama:
+                // Endpoint reachability is not pre-checked; let connection errors surface.
+                break;
+        }
     }
 
     private static IChatClient CreateOllamaChatClient(EvalModelConfig model)

--- a/lucia.Tests/Wyoming/ModelDownloaderTests.cs
+++ b/lucia.Tests/Wyoming/ModelDownloaderTests.cs
@@ -94,10 +94,12 @@ public sealed class ModelDownloaderTests : IDisposable
     [Fact]
     public async Task DownloadModelAsync_TarGzUrl_TreatedAsArchive()
     {
-        // Arrange
+        // Arrange — 32 bytes of garbage so SharpCompress's format-detection
+        // buffer is filled enough to raise InvalidFormatException (it raises
+        // EndOfStreamException on shorter streams since SharpCompress 1.0.0).
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent([0x00, 0x01, 0x02]),
+            Content = new ByteArrayContent(new byte[32]),
         });
 
         var downloader = CreateDownloader(handler);
@@ -113,10 +115,11 @@ public sealed class ModelDownloaderTests : IDisposable
     [Fact]
     public async Task DownloadModelAsync_ZipUrl_TreatedAsArchive()
     {
-        // Arrange
+        // Arrange — see DownloadModelAsync_TarGzUrl_TreatedAsArchive for the
+        // 32-byte rationale (SharpCompress 1.0.0 format-detection floor).
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent([0x00]),
+            Content = new ByteArrayContent(new byte[32]),
         });
 
         var downloader = CreateDownloader(handler);
@@ -179,10 +182,12 @@ public sealed class ModelDownloaderTests : IDisposable
     [Fact]
     public async Task DownloadModelAsync_UrlWithNoFileName_FallsBackToModelIdArchive()
     {
-        // Arrange — a URL whose path is "/" so GetDownloadFileName returns "{modelId}.tar.bz2"
+        // Arrange — a URL whose path is "/" so GetDownloadFileName returns "{modelId}.tar.bz2".
+        // 32 bytes of garbage so SharpCompress reaches its format-detection floor and
+        // throws InvalidFormatException (smaller streams raise EndOfStreamException in 1.0.0).
         var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent([0x00]),
+            Content = new ByteArrayContent(new byte[32]),
         });
 
         var downloader = CreateDownloader(handler);

--- a/lucia.Wyoming/Models/ModelDownloader.cs
+++ b/lucia.Wyoming/Models/ModelDownloader.cs
@@ -216,17 +216,18 @@ public sealed class ModelDownloader(
 
     private static void ExtractArchive(string archivePath, string extractionDirectory, IProgress<ProgressReport>? onProgress = null)
     {
-        // SharpCompress uses Constants.RewindableBufferSize for the ring buffer during
-        // format detection. The default (81920) is too small for bz2-compressed tar archives
-        // where ~800KB of decompressed data must be inspected to confirm the inner tar format.
-        // ReaderOptions.WithRewindableBufferSize doesn't flow through to the stream constructor,
-        // so we set the static default directly.
-        Constants.RewindableBufferSize = 1_048_576;
+        // SharpCompress 1.0.0 surfaces the rewindable/format-detection buffer via
+        // ReaderOptions.BufferSize. The default (81920) is too small for bz2-compressed
+        // tar archives where ~800KB of decompressed data must be inspected to confirm
+        // the inner tar format, so we enlarge the buffer to 1MB.
+        var options = new ReaderOptions
+        {
+            BufferSize = 1_048_576,
+            Progress = onProgress,
+        };
 
-        var options = ReaderOptions.ForFilePath
-            .WithProgress(onProgress);
         using var stream = File.OpenRead(archivePath);
-        using var reader = ReaderFactory.OpenReader(stream, options);
+        using var reader = ReaderFactory.Open(stream, options);
 
         while (reader.MoveToNextEntry())
         {


### PR DESCRIPTION
## Summary

Aspire `13.4.2` (and the related client integrations) bring in newer transitive dependencies that were causing `NU1109` package-downgrade errors across the solution after the recent Aspire upgrade. This PR aligns the centrally managed versions in `Directory.Packages.props` with those new floors, bumps the `Aspire.AppHost.Sdk` to match the hosting packages, and migrates `ModelDownloader` to the SharpCompress `1.0.0` API.

## Package updates (`Directory.Packages.props`)

| Package | Old | New |
| --- | --- | --- |
| `Microsoft.Extensions.AI` / `.Abstractions` / `.OpenAI` | 10.5.0 | 10.6.0 |
| `Microsoft.Extensions.*` (core: DI, Hosting, Options, Logging, Http, Caching.Memory, Data.Sqlite, System.Text.Json) | 10.0.7 | 10.0.8 |
| `Microsoft.Extensions.Configuration.*` | 10.0.7 | 10.0.8 |
| `StackExchange.Redis` | 2.12.8 | 2.13.1 |
| `ModelContextProtocol` | 1.1.0 | 1.3.0 |
| `MongoDB.Driver` | 3.7.1 | 3.8.1 |
| `SharpCompress` | 0.48.1 | 1.0.0 |

## Other changes

- `lucia.AppHost.csproj`: `Aspire.AppHost.Sdk` `13.3.3` → `13.4.2`.
- `lucia.Wyoming/Models/ModelDownloader.cs`: migrated to SharpCompress 1.0.0. The 1.0 release removed `Constants.RewindableBufferSize`, `ReaderOptions.ForFilePath`, the `WithProgress` fluent extension, and `ReaderFactory.OpenReader`. Replaced with `new ReaderOptions { BufferSize = 1_048_576, Progress = onProgress }` and `ReaderFactory.Open(stream, options)`. The 1 MB buffer is preserved to keep bz2-compressed tar detection working.

## Verification

- `dotnet restore lucia-dotnet.slnx` — no NU1109 (or other) errors.
- `dotnet build lucia-dotnet.slnx --no-restore` — `Build succeeded` with 0 errors.