### PR TITLE
fix(dashboard): useActivityStream reconnect-timer leak (#133)

### DIFF
--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -36,14 +36,11 @@ MeshGraph, PluginRepoDialog, PluginConfigTab, RestartBanner, SkillConfigEditor, 
 - **API-boundary type safety**: Several pages cast raw API results with `as` (VoicePlatformPage 384-385/861/879/885, MatcherDebugPage:164) and `api.ts searchEntityLocation` returns `Promise<any>`. Prefer typing the `api.ts` functions concretely and narrowing, rather than casting at call sites.
 - **Swallowed fetch errors**: Common pattern of `.catch(() => {})` on startup fetches (MatcherDebugPage 112-125, ConfigurationPage 442-447, VoicePlatformPage 302-303) silently degrades UI with no user signal. Watch for missing error states when reviewing data fetching.
 - **Review hygiene confirmed**: dashboard has no `dangerouslySetInnerHTML`, no hardcoded secrets, all API calls use relative `/api` via the single typed `api.ts` client.
+- **useActivityStream timer fix (2026-07-10, issue #133)**: Fixed post-unmount timer leak by mirroring `useCommandTraceStream`: added `retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)`, stored the ID in `onerror`, cleared it at the top of `connect()` (cancels prior retry on reconnect), and cleared it in the effect cleanup (stops pending timer on unmount). This prevents a phantom EventSource + post-unmount `setState` when the component unmounts during a backoff delay. PR #219.
+- **Error UI for useQuery fetches (issue #143, 2026-05-30)**: `ResponseTemplatesPage` now destructures `isError`/`refetch` from both `useQuery` hooks and renders a styled error panel (ember border + retry button) in the template-groups section; a narrower inline banner handles command-pattern failures. `SkillOptimizerPage` had no TanStack Query — replaced the fire-and-forget `useEffect` with a `loadInit` `useCallback` tracked by `isLoadingInit`/`initError` state; a loading skeleton renders during init and a retryable error panel replaces the content area on failure. PR #190.
 
 - Participated in 2026-05-29 health review
 
-## Learnings
-
-- **useActivityStream timer fix (2026-07-10, issue #133)**: Fixed post-unmount timer leak by mirroring `useCommandTraceStream`: added `retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)`, stored the ID in `onerror`, cleared it at the top of `connect()` (cancels prior retry on reconnect), and cleared it in the effect cleanup (stops pending timer on unmount). This prevents a phantom EventSource + post-unmount `setState` when the component unmounts during a backoff delay. PR #219.
 ---
 
 **Update from Ripley (2026-05-30):** Inbox retriage complete. You have been assigned issues from the 2026-05-30 batch. Review .squad/decisions/decisions.md for details.
-
-- **Error UI for useQuery fetches (issue #143, 2026-05-30)**: `ResponseTemplatesPage` now destructures `isError`/`refetch` from both `useQuery` hooks and renders a styled error panel (ember border + retry button) in the template-groups section; a narrower inline banner handles command-pattern failures. `SkillOptimizerPage` had no TanStack Query — replaced the fire-and-forget `useEffect` with a `loadInit` `useCallback` tracked by `isLoadingInit`/`initError` state; a loading skeleton renders during init and a retryable error panel replaces the content area on failure. PR #190.

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -38,6 +38,10 @@ MeshGraph, PluginRepoDialog, PluginConfigTab, RestartBanner, SkillConfigEditor, 
 - **Review hygiene confirmed**: dashboard has no `dangerouslySetInnerHTML`, no hardcoded secrets, all API calls use relative `/api` via the single typed `api.ts` client.
 
 - Participated in 2026-05-29 health review
+
+## Learnings
+
+- **useActivityStream timer fix (2026-07-10, issue #133)**: Fixed post-unmount timer leak by mirroring `useCommandTraceStream`: added `retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)`, stored the ID in `onerror`, cleared it at the top of `connect()` (cancels prior retry on reconnect), and cleared it in the effect cleanup (stops pending timer on unmount). This prevents a phantom EventSource + post-unmount `setState` when the component unmounts during a backoff delay. PR #219.
 ---
 
 **Update from Ripley (2026-05-30):** Inbox retriage complete. You have been assigned issues from the 2026-05-30 batch. Review .squad/decisions/decisions.md for details.

--- a/lucia-dashboard/src/hooks/useActivityStream.ts
+++ b/lucia-dashboard/src/hooks/useActivityStream.ts
@@ -19,9 +19,14 @@ export function useActivityStream() {
   const sourceRef = useRef<EventSource | null>(null)
   const connectRef = useRef<(() => void) | null>(null)
   const retriesRef = useRef(0)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const maxRetries = 10
 
   const connect = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current)
+      retryTimerRef.current = null
+    }
     if (sourceRef.current) {
       sourceRef.current.close()
     }
@@ -55,7 +60,7 @@ export function useActivityStream() {
         setConnectionState('reconnecting')
         const delay = Math.min(1000 * Math.pow(2, retriesRef.current), 30000)
         retriesRef.current++
-        setTimeout(() => connectRef.current?.(), delay)
+        retryTimerRef.current = setTimeout(() => connectRef.current?.(), delay)
       } else {
         setConnectionState('disconnected')
       }
@@ -74,6 +79,10 @@ export function useActivityStream() {
   useEffect(() => {
     connect()
     return () => {
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
       sourceRef.current?.close()
       sourceRef.current = null
     }


### PR DESCRIPTION
Mirrored retryTimerRef pattern from useCommandTraceStream. Stored the setTimeout ID, clear it at connect() entry, and clear it in the effect cleanup. Prevents post-unmount EventSource creation and setState calls when component unmounts during a backoff delay. Build: npm run build passes 0 errors. Closes #133