### PR TITLE
fix(docker): voice image CUDA version compatibility (#207)

### DIFF
--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -47,6 +47,33 @@
 
 <!-- Append new learnings below. -->
 
+### 2026-07-10: CUDA/ORT Version Compatibility — Issue #207 (PR squad/207-docker-voice-cuda)
+
+**Root cause:** `Dockerfile.voice` Stage 1 base image was pinned to `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04`
+while ORT 1.23.2 GPU libs (csukuangfj patched, from `asset.lock`) are compiled against CUDA 12.8 symbols.
+Loading a CUDA 12.8-linked `libonnxruntime_providers_cuda.so` inside a CUDA 12.6 container causes
+`cudaErrorInsufficientDriver` (error 35) at `cudaSetDevice()` because the 12.6 runtime lacks the
+required symbol versions. The Dockerfile header comment already stated 12.8.1 as the intended target —
+the FROM line was never updated to match.
+
+**Secondary factor:** CUDA 12.8 is the first release with full Blackwell (sm_120 / GB202) support.
+RTX 5090 users on driver 590.xx hit both the symbol mismatch and the architecture gap simultaneously.
+
+**Fix:** Updated Stage 1 FROM to `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:ac55d124da4882b497f732d8dfd9a702d5447a5f29d08d56da6f64f0a1eb34bc`.
+Validated: `docker build --target base` succeeded against the new digest.
+
+**CUDA/ORT Compatibility Matrix (ORT 1.23.x):**
+- ORT 1.23.2 → CUDA 12.8.x → cuDNN 9.x → min driver 570.86.10 → Blackwell sm_120 ✅
+- ORT 1.23.2 on CUDA 12.6.x → cudaErrorInsufficientDriver on Blackwell or symbol mismatch ⚠️
+
+**Rule:** When bumping ORT GPU version, verify the CUDA base image matches what the ORT libs link against.
+Use `readelf -d libonnxruntime_providers_cuda.so | grep NEEDED` or check csukuangfj release notes.
+Always keep `asset.lock` onnxruntime-gpu version and base image CUDA version in sync.
+Minimum host driver for CUDA 12.8 is **570.86.10** (user's 590.48.01 is compatible).
+
+**CPU fallback:** `:voice-cpu` tag uses `mcr.microsoft.com/dotnet/aspnet:10.0` — no CUDA dependency.
+Recommend documenting this as the explicit fallback for non-NVIDIA hosts or unsupported GPU generations.
+
 ### 2026-05-31: Jetson Non-Voice Deploy — RETRY SUCCESS (full on-device build & validate)
 
 **Connectivity resolution**: The 192.168.0.x→192.168.1.x subnet gap from the previous run was resolved by Zack bouncing the Jetson. SSH to `zackw@192.168.1.239` connected cleanly with key-based auth (BatchMode=yes, ConnectTimeout=10). L3 ping RTT: 3–23ms.

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -77,7 +77,7 @@ Full runtime validation (ONNX CUDAExecutionProvider init on a physical GPU) stil
 **Rule:** When bumping ORT GPU version, verify the CUDA base image against the upstream ORT release notes
 and the csukuangfj artifact build logs/metadata to confirm the target CUDA version. `readelf -d` reports
 major-version SONAMEs only (e.g. `libcudart.so.12`) and cannot distinguish minor versions.
-Always keep `asset.lock` onnxruntime-gpu version and base image CUDA version in sync.
+Always keep the ORT version in `asset.lock` in sync with the CUDA base image version (note: `asset.lock` records the ORT release version, not a CUDA minor version — verify the required CUDA target from ORT release notes or artifact build metadata).
 Host driver requirements vary by GPU family and CUDA minor version — consult
 https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/ rather than assuming a single minimum.
 

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -49,27 +49,36 @@
 
 ### 2026-07-10: CUDA/ORT Version Compatibility — Issue #207 (PR squad/207-docker-voice-cuda)
 
-**Root cause:** `Dockerfile.voice` Stage 1 base image was pinned to `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04`
-while ORT 1.23.2 GPU libs (csukuangfj patched, from `asset.lock`) are compiled against CUDA 12.8 symbols.
-Loading a CUDA 12.8-linked `libonnxruntime_providers_cuda.so` inside a CUDA 12.6 container causes
-`cudaErrorInsufficientDriver` (error 35) at `cudaSetDevice()` because the 12.6 runtime lacks the
-required symbol versions. The Dockerfile header comment already stated 12.8.1 as the intended target —
-the FROM line was never updated to match.
+**CONFIRMED:** `Dockerfile.voice` Stage 1 base image was pinned to `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04`
+while the intended target (already documented in the Dockerfile header comment) was `12.8.1` — the FROM
+line was never updated to match. The csukuangfj ORT 1.23.2 artifact repackages the upstream release by
+changing SONAMEs rather than rebuilding; its exact runtime CUDA version requirement was not independently
+verified from the artifact metadata.
 
-**Secondary factor:** CUDA 12.8 is the first release with full Blackwell (sm_120 / GB202) support.
-RTX 5090 users on driver 590.xx hit both the symbol mismatch and the architecture gap simultaneously.
+**CONFIRMED:** CUDA 12.8 is required for full Blackwell (sm_120 / GB202) support. RTX 5090 users would
+fail to initialise the CUDA device regardless of the ORT library loading behaviour.
+
+**HYPOTHESIZED (unverified — needs GPU-host runtime test):** The exact mechanism producing
+`cudaErrorInsufficientDriver` (error 35) at `cudaSetDevice()`. `cudaErrorInsufficientDriver` indicates the
+loaded CUDA runtime cannot use the driver — distinct from a missing-symbol load failure. The true trigger
+(version mismatch, Blackwell arch, or both) requires a physical GPU-host test to confirm.
 
 **Fix:** Updated Stage 1 FROM to `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:ac55d124da4882b497f732d8dfd9a702d5447a5f29d08d56da6f64f0a1eb34bc`.
-Validated: `docker build --target base` succeeded against the new digest.
 
-**CUDA/ORT Compatibility Matrix (ORT 1.23.x):**
-- ORT 1.23.2 → CUDA 12.8.x → cuDNN 9.x → min driver 570.86.10 → Blackwell sm_120 ✅
-- ORT 1.23.2 on CUDA 12.6.x → cudaErrorInsufficientDriver on Blackwell or symbol mismatch ⚠️
+**Validated (confirmed):** `docker build --target base` succeeded — new CUDA 12.8.1 base image pulls and
+all base-stage layers build. This does NOT load the overlaid ORT GPU libs or call `cudaSetDevice()`.
+Full runtime validation (ONNX CUDAExecutionProvider init on a physical GPU) still needed.
 
-**Rule:** When bumping ORT GPU version, verify the CUDA base image matches what the ORT libs link against.
-Use `readelf -d libonnxruntime_providers_cuda.so | grep NEEDED` or check csukuangfj release notes.
+**CUDA/ORT Compatibility Matrix (ORT 1.23.x) — based on upstream docs, not locally verified:**
+- ORT 1.23.2 + CUDA 12.8.x + cuDNN 9.x: Blackwell sm_120 ✅ (per NVIDIA release notes)
+- ORT 1.23.2 + CUDA 12.6.x: Blackwell sm_120 ⚠️ fails; ORT runtime behaviour unverified
+
+**Rule:** When bumping ORT GPU version, verify the CUDA base image against the upstream ORT release notes
+and the csukuangfj artifact build logs/metadata to confirm the target CUDA version. `readelf -d` reports
+major-version SONAMEs only (e.g. `libcudart.so.12`) and cannot distinguish minor versions.
 Always keep `asset.lock` onnxruntime-gpu version and base image CUDA version in sync.
-Minimum host driver for CUDA 12.8 is **570.86.10** (user's 590.48.01 is compatible).
+Host driver requirements vary by GPU family and CUDA minor version — consult
+https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/ rather than assuming a single minimum.
 
 **CPU fallback:** `:voice-cpu` tag uses `mcr.microsoft.com/dotnet/aspnet:10.0` — no CUDA dependency.
 Recommend documenting this as the explicit fallback for non-NVIDIA hosts or unsupported GPU generations.

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -55,8 +55,9 @@ line was never updated to match. The csukuangfj ORT 1.23.2 artifact repackages t
 changing SONAMEs rather than rebuilding; its exact runtime CUDA version requirement was not independently
 verified from the artifact metadata.
 
-**CONFIRMED:** CUDA 12.8 is required for full Blackwell (sm_120 / GB202) support. RTX 5090 users would
-fail to initialise the CUDA device regardless of the ORT library loading behaviour.
+**CONFIRMED (per NVIDIA release notes):** CUDA 12.8 is the first toolkit release with native sm_120
+(Blackwell / GB202) support. A CUDA 12.6 runtime is not a supported configuration for Blackwell; while
+driver forward-compat may allow some operations in specific cases, native sm_120 support requires 12.8+.
 
 **HYPOTHESIZED (unverified — needs GPU-host runtime test):** The exact mechanism producing
 `cudaErrorInsufficientDriver` (error 35) at `cudaSetDevice()`. `cudaErrorInsufficientDriver` indicates the
@@ -70,8 +71,8 @@ all base-stage layers build. This does NOT load the overlaid ORT GPU libs or cal
 Full runtime validation (ONNX CUDAExecutionProvider init on a physical GPU) still needed.
 
 **CUDA/ORT Compatibility Matrix (ORT 1.23.x) — based on upstream docs, not locally verified:**
-- ORT 1.23.2 + CUDA 12.8.x + cuDNN 9.x: Blackwell sm_120 ✅ (per NVIDIA release notes)
-- ORT 1.23.2 + CUDA 12.6.x: Blackwell sm_120 ⚠️ fails; ORT runtime behaviour unverified
+- CUDA 12.8.x: native sm_120 (Blackwell) support per NVIDIA release notes; this image not yet runtime-tested on GPU host
+- CUDA 12.6.x: sm_120 not natively supported per NVIDIA release notes; not a supported configuration for Blackwell
 
 **Rule:** When bumping ORT GPU version, verify the CUDA base image against the upstream ORT release notes
 and the csukuangfj artifact build logs/metadata to confirm the target CUDA version. `readelf -d` reports

--- a/infra/docker/Dockerfile.voice
+++ b/infra/docker/Dockerfile.voice
@@ -65,10 +65,15 @@ RUN npm run build
 # ============================================================================
 # Stage 1: Base Runtime Image (NVIDIA CUDA 12.8 + cuDNN 9 for GPU ONNX)
 # ============================================================================
-# CUDA 12.8.1 is required: ORT 1.23.2 GPU libs (csukuangfj patched) are
-# compiled against CUDA 12.8 symbols. Using 12.6 causes cudaErrorInsufficientDriver
-# (error 35) at cudaSetDevice(). Also ensures Blackwell (sm_120, RTX 5090)
-# and later GPUs receive proper support. Minimum host driver: 570.86.10.
+# CUDA 12.8.1 is required for two confirmed reasons:
+#   1. Version alignment: the prior 12.6.3 base was a mismatch against the ORT
+#      1.23.2 GPU artifact (asset.lock) — exact runtime failure mechanism on a
+#      GPU host is still unverified (needs runtime test); see issue #207.
+#   2. Blackwell support: CUDA 12.8 is the first release with full sm_120
+#      (RTX 5090 / GB202) support. CUDA 12.6 containers fail to initialise on
+#      Blackwell hardware regardless of host driver version.
+# Host driver requirements vary by GPU family and CUDA minor version; consult
+# https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/ for your GPU.
 # See: https://github.com/seiggy/lucia-dotnet/issues/207
 FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:ac55d124da4882b497f732d8dfd9a702d5447a5f29d08d56da6f64f0a1eb34bc AS base
 

--- a/infra/docker/Dockerfile.voice
+++ b/infra/docker/Dockerfile.voice
@@ -9,7 +9,7 @@
 # Stages:
 #   0. assets         — Pre-built OCI image with all binary downloads
 #   0b. node-build    — Build the React SPA dashboard with Node.js
-#    1. base          — NVIDIA CUDA 12.8 runtime with .NET ASP.NET 10.0
+#    1. base          — NVIDIA CUDA 12.8.1 runtime with .NET ASP.NET 10.0
 #    2. build         — Restore and build the .NET application with SDK
 #    3. publish       — Publish optimized ReadyToRun release build
 #    4. final         — Production image with health checks, security, and voice models
@@ -63,9 +63,14 @@ COPY lucia-dashboard/ ./
 RUN npm run build
 
 # ============================================================================
-# Stage 1: Base Runtime Image (NVIDIA CUDA 12.6 + cuDNN 9 for GPU ONNX)
+# Stage 1: Base Runtime Image (NVIDIA CUDA 12.8 + cuDNN 9 for GPU ONNX)
 # ============================================================================
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04@sha256:8aef630a54bc5c5146ae5ce68e6af5caa3df0fb690bb91544175c91f307e4356 AS base
+# CUDA 12.8.1 is required: ORT 1.23.2 GPU libs (csukuangfj patched) are
+# compiled against CUDA 12.8 symbols. Using 12.6 causes cudaErrorInsufficientDriver
+# (error 35) at cudaSetDevice(). Also ensures Blackwell (sm_120, RTX 5090)
+# and later GPUs receive proper support. Minimum host driver: 570.86.10.
+# See: https://github.com/seiggy/lucia-dotnet/issues/207
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:ac55d124da4882b497f732d8dfd9a702d5447a5f29d08d56da6f64f0a1eb34bc AS base
 
 # Install .NET ASP.NET 10.0 runtime + curl for healthcheck
 # + python3 + huggingface-hub[cli] (pinned) for runtime HF model downloads via the `hf` CLI

--- a/infra/docker/Dockerfile.voice
+++ b/infra/docker/Dockerfile.voice
@@ -65,14 +65,16 @@ RUN npm run build
 # ============================================================================
 # Stage 1: Base Runtime Image (NVIDIA CUDA 12.8 + cuDNN 9 for GPU ONNX)
 # ============================================================================
-# CUDA 12.8.1 is required for two confirmed reasons:
-#   1. Version alignment: the prior 12.6.3 base was a mismatch against the ORT
-#      1.23.2 GPU artifact (asset.lock) — exact runtime failure mechanism on a
-#      GPU host is still unverified (needs runtime test); see issue #207.
-#   2. Blackwell support: CUDA 12.8 is the first toolkit release with native
-#      sm_120 (RTX 5090 / GB202) support per NVIDIA release notes. A CUDA 12.6
-#      runtime is not a supported configuration for Blackwell; behaviour may
-#      vary depending on driver forward-compat, but native support requires 12.8+.
+# CUDA 12.8.1 is used here for one confirmed reason:
+#   CONFIRMED: CUDA 12.8 is the first toolkit release with native sm_120
+#   (RTX 5090 / GB202, Blackwell) support per NVIDIA release notes. A CUDA
+#   12.6 base is not a supported configuration for Blackwell; native sm_120
+#   support requires 12.8+.
+# UNVERIFIED (pending GPU runtime test): whether the ORT 1.23.2 GPU artifact
+#   also requires CUDA 12.8 at runtime. The prior 12.6.3 base was a version
+#   mismatch vs. the intended 12.8.1 (the FROM line was never updated to match
+#   the header comment), but the exact ORT failure mechanism on a 12.6 host is
+#   unresolved until a physical GPU test is run; see issue #207.
 # Host driver requirements vary by GPU family and CUDA minor version; consult
 # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/ for your GPU.
 # See: https://github.com/seiggy/lucia-dotnet/issues/207

--- a/infra/docker/Dockerfile.voice
+++ b/infra/docker/Dockerfile.voice
@@ -69,9 +69,10 @@ RUN npm run build
 #   1. Version alignment: the prior 12.6.3 base was a mismatch against the ORT
 #      1.23.2 GPU artifact (asset.lock) — exact runtime failure mechanism on a
 #      GPU host is still unverified (needs runtime test); see issue #207.
-#   2. Blackwell support: CUDA 12.8 is the first release with full sm_120
-#      (RTX 5090 / GB202) support. CUDA 12.6 containers fail to initialise on
-#      Blackwell hardware regardless of host driver version.
+#   2. Blackwell support: CUDA 12.8 is the first toolkit release with native
+#      sm_120 (RTX 5090 / GB202) support per NVIDIA release notes. A CUDA 12.6
+#      runtime is not a supported configuration for Blackwell; behaviour may
+#      vary depending on driver forward-compat, but native support requires 12.8+.
 # Host driver requirements vary by GPU family and CUDA minor version; consult
 # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/ for your GPU.
 # See: https://github.com/seiggy/lucia-dotnet/issues/207


### PR DESCRIPTION
## Summary

The voice GPU image (`Dockerfile.voice`) Stage 1 base was pinned to `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04`, while the Dockerfile's own header comment and intent targeted `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04`. The `FROM` line was never updated to match. This PR pins the base to the intended CUDA 12.8.1 image (digest-pinned per decision #20).

## Confirmed rationale

- **Blackwell (sm_120) native support requires CUDA 12.8+.** RTX 5090 / GB202 (compute capability 12.0) is natively supported starting with the CUDA 12.8 toolkit per NVIDIA release notes; a CUDA 12.6 runtime is **not a supported configuration** for Blackwell.
- The base-stage build (`docker build --target base`) succeeds against the new `sha256:ac55d124...` digest on x86_64.

## Hypothesized / NOT yet verified

- The exact `cudaErrorInsufficientDriver` (error 35) failure mechanism, and whether ORT 1.23.2's GPU libraries specifically require CUDA 12.8-era symbols vs. a driver/architecture mismatch, is **not independently verified** in this PR. The csukuangfj artifact records only the ORT release version; its exact CUDA build target should be confirmed from ORT release notes / artifact build metadata before being asserted as fact.
- Precise minimum host driver versions vary by GPU family and CUDA minor version — no single universal minimum is claimed here.

## Fix

```dockerfile
FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04@sha256:ac55d124da4882b497f732d8dfd9a702d5447a5f29d08d56da6f64f0a1eb34bc AS base
```

Digest retained per decision #20 (base image digest pinning). Inline comments reworded to separate confirmed facts from hypothesized failure mechanism.

## Validation

- ✅ `docker build --target base` succeeded against the new digest on x86_64.
- ⚠️ **Full GPU runtime test still required** on a CUDA-capable host (ONNX CUDAExecutionProvider init + inference on a physical NVIDIA GPU, ideally a Blackwell device) before the runtime fix can be marked fully proven.

## CPU fallback

Users without a supported GPU should use the `:voice-cpu` tag (`Dockerfile.voice-cpu`), based on `mcr.microsoft.com/dotnet/aspnet:10.0` with no CUDA dependencies.

Closes #207