### PR TITLE
fix(eval): evaluate sweep combos N times before selecting winner (#134)

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -17,12 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build and test
-        run: |
-          # TODO: Add your dotnet build/test commands here
-          # Go:            go test ./...
-          # Python:        pip install -r requirements.txt && pytest
-          # .NET:          dotnet test
-          # Java (Maven):  mvn test
-          # Java (Gradle): ./gradlew test
-          echo "No build commands configured — update squad-ci.yml"
+      - name: Set up .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore dependencies
+        run: dotnet restore lucia-dotnet.slnx
+
+      - name: Build
+        run: dotnet build lucia-dotnet.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test lucia.Tests --no-build --configuration Release --filter "Category!=Eval&Category!=Integration" --logger "console;verbosity=normal"
+
+      - name: Test EvalHarness (provider-free)
+        run: dotnet test lucia.EvalHarness.Tests --no-build --configuration Release --logger "console;verbosity=normal"

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -178,6 +178,32 @@
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
 - Participated in 2026-05-29 health review
+
+## Learnings
+
+### 2026-07-10: Multi-run sweep aggregation (issue #134)
+
+**What I implemented:**
+- `ParameterSweepConfig.RunsPerCombination` (default 3) — configures how many times each sweep combination is evaluated before a winner is selected.
+- `SweepRunAggregator` — pure static class with no external dependencies: `ComputeMean`, `ComputeVariance`, `ComputeMinRunMean`, `SelectWinner`, `DeriveRunSeed`.
+- `SweepEntry` updated: `AllRunResults` (all N run results), `MeanScore`, `ScoreVariance`, `MinRunMean`. `AverageScore` is now an alias for `MeanScore` for backward compatibility with report generators.
+- `ParameterSweepRunner.RunAsync` loops N times per combination; each run gets `baseSeed + runIndex` when a seed is configured.
+- New `lucia.EvalHarness.Tests` project (18 fast provider-free tests).
+
+**Aggregation strategy:**
+- Primary criterion: highest mean score across N runs
+- Tie-breaker: lower score variance (stable config beats volatile one on equal means)
+- This prevents a single lucky run from being misreported as the best configuration.
+
+**Architectural patterns:**
+- `lucia.EvalHarness` (Exe) cannot be a test project itself — created `lucia.EvalHarness.Tests` as a separate csproj in the solution's Tests folder.
+- `lucia.EvalHarness.Tests` references `lucia.EvalHarness` but NOT `lucia.Tests` — avoids circular dependency.
+- Global using `<Using Include="Xunit" />` needed in the new test project (not inherited from Directory.Build.props).
+- Collection expression syntax `[item1, item2]` inside `new List<T> { ... }` initializers is parsed as indexer access, NOT a collection expression — use explicit `new List<T> { item1, item2 }` instead.
+
+**Build verification:**
+- `dotnet build lucia-dotnet.slnx -v minimal` — 0 warnings, 0 errors
+- `dotnet test lucia.EvalHarness.Tests` — 18/18 passed, 154ms
 ---
 
 **Update from Ripley (2026-05-30):** Inbox retriage complete. You have been assigned issues from the 2026-05-30 batch. Review .squad/decisions/decisions.md for details.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -188,7 +188,7 @@
 - `SweepRunAggregator` — pure static class with no external dependencies: `ComputeMean`, `ComputeVariance`, `ComputeMinRunMean`, `SelectWinner`, `DeriveRunSeed`.
 - `SweepEntry` updated: `AllRunResults` (all N run results), `MeanScore`, `ScoreVariance`, `MinRunMean`. `AverageScore` is now an alias for `MeanScore` for backward compatibility with report generators.
 - `ParameterSweepRunner.RunAsync` loops N times per combination; each run gets `baseSeed + runIndex` when a seed is configured.
-- New `lucia.EvalHarness.Tests` project (18 fast provider-free tests).
+- New `lucia.EvalHarness.Tests` project (30 fast provider-free tests).
 
 **Aggregation strategy:**
 - Primary criterion: highest mean score across N runs
@@ -203,7 +203,7 @@
 
 **Build verification:**
 - `dotnet build lucia-dotnet.slnx -v minimal` — 0 warnings, 0 errors
-- `dotnet test lucia.EvalHarness.Tests` — 18/18 passed, 154ms
+- `dotnet test lucia.EvalHarness.Tests` — 30/30 passed
 ---
 
 **Update from Ripley (2026-05-30):** Inbox retriage complete. You have been assigned issues from the 2026-05-30 batch. Review .squad/decisions/decisions.md for details.

--- a/lucia-dotnet.slnx
+++ b/lucia-dotnet.slnx
@@ -35,6 +35,7 @@
   <Folder Name="/Tests/">
     <Project Path="lucia.Tests/lucia.Tests.csproj" />
     <Project Path="lucia.EvalHarness/lucia.EvalHarness.csproj" />
+    <Project Path="lucia.EvalHarness.Tests/lucia.EvalHarness.Tests.csproj" />
   </Folder>
   <Folder Name="/Voice/">
     <Project Path="lucia.Wyoming/lucia.Wyoming.csproj" />

--- a/lucia.EvalHarness.Tests/ParameterSweepAggregationTests.cs
+++ b/lucia.EvalHarness.Tests/ParameterSweepAggregationTests.cs
@@ -1,0 +1,249 @@
+using lucia.EvalHarness.Configuration;
+using lucia.EvalHarness.Evaluation;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Fast, provider-free tests for parameter-sweep aggregation logic.
+/// These tests verify that each combination is run N times and that the winner
+/// is selected on mean score across all runs rather than a single lucky sample.
+/// </summary>
+public sealed class ParameterSweepAggregationTests
+{
+    // ──────────────────────────────────────────────────────────────
+    // ParameterSweepConfig defaults
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RunsPerCombination_DefaultsToThree()
+    {
+        var config = new ParameterSweepConfig();
+        Assert.Equal(3, config.RunsPerCombination);
+    }
+
+    [Fact]
+    public void RunsPerCombination_CanBeConfigured()
+    {
+        var config = new ParameterSweepConfig { RunsPerCombination = 5 };
+        Assert.Equal(5, config.RunsPerCombination);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // SweepRunAggregator.ComputeMean
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeMean_ReturnsZero_WhenNoRuns()
+    {
+        var mean = SweepRunAggregator.ComputeMean(new List<IReadOnlyList<ModelEvalResult>>());
+        Assert.Equal(0.0, mean);
+    }
+
+    [Fact]
+    public void ComputeMean_SingleRun_EqualsRunScore()
+    {
+        var allRuns = Runs(Run(80.0));
+        var mean = SweepRunAggregator.ComputeMean(allRuns);
+        Assert.Equal(80.0, mean);
+    }
+
+    [Fact]
+    public void ComputeMean_MultipleRuns_ReturnsAcrossAllRunsAndAgents()
+    {
+        // 3 runs: 60, 80, 100 -> mean = 80
+        var allRuns = Runs(Run(60.0), Run(80.0), Run(100.0));
+        var mean = SweepRunAggregator.ComputeMean(allRuns);
+        Assert.Equal(80.0, mean, precision: 6);
+    }
+
+    [Fact]
+    public void ComputeMean_MultipleAgentsPerRun_AveragesAcrossAll()
+    {
+        // 2 runs x 2 agents: (50+70) + (60+80) = 260 / 4 = 65
+        var allRuns = new List<IReadOnlyList<ModelEvalResult>>
+        {
+            new List<ModelEvalResult> { MakeResult(50.0), MakeResult(70.0) },
+            new List<ModelEvalResult> { MakeResult(60.0), MakeResult(80.0) }
+        };
+        var mean = SweepRunAggregator.ComputeMean(allRuns);
+        Assert.Equal(65.0, mean, precision: 6);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // SweepRunAggregator.ComputeVariance
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVariance_SingleRun_ReturnsZero()
+    {
+        var variance = SweepRunAggregator.ComputeVariance(Runs(Run(70.0)));
+        Assert.Equal(0.0, variance);
+    }
+
+    [Fact]
+    public void ComputeVariance_IdenticalRuns_ReturnsZero()
+    {
+        var allRuns = Runs(Run(75.0), Run(75.0), Run(75.0));
+        var variance = SweepRunAggregator.ComputeVariance(allRuns);
+        Assert.Equal(0.0, variance, precision: 6);
+    }
+
+    [Fact]
+    public void ComputeVariance_VaryingRuns_IsPositive()
+    {
+        var allRuns = Runs(Run(50.0), Run(100.0));
+        var variance = SweepRunAggregator.ComputeVariance(allRuns);
+        Assert.True(variance > 0, "Variance of 50 and 100 should be positive");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // SweepRunAggregator.SelectWinner
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SelectWinner_PicksHighestMean_NotSingleRunWinner()
+    {
+        // Profile A: single noisy run of 95, but mean is (95+40+40)/3 = 58.3
+        // Profile B: steady runs of 75, mean = 75 -> B is the true winner
+        var entryA = MakeSweepEntry(MakeProfile("A"), 95.0, 40.0, 40.0);
+        var entryB = MakeSweepEntry(MakeProfile("B"), 75.0, 75.0, 75.0);
+
+        var winner = SweepRunAggregator.SelectWinner(new List<SweepEntry> { entryA, entryB });
+
+        Assert.Equal("B", winner.Profile.Name);
+    }
+
+    [Fact]
+    public void SelectWinner_TieOnMean_PrefersLowerVariance()
+    {
+        // Both have mean 75, but A is volatile (50/100) while B is stable (75/75)
+        var entryA = MakeSweepEntry(MakeProfile("A"), 50.0, 100.0);
+        var entryB = MakeSweepEntry(MakeProfile("B"), 75.0, 75.0);
+
+        var winner = SweepRunAggregator.SelectWinner(new List<SweepEntry> { entryA, entryB });
+
+        Assert.Equal("B", winner.Profile.Name);
+    }
+
+    [Fact]
+    public void SelectWinner_SingleEntry_ReturnsThatEntry()
+    {
+        var entry = MakeSweepEntry(MakeProfile("only"), 65.0);
+        var winner = SweepRunAggregator.SelectWinner(new List<SweepEntry> { entry });
+        Assert.Equal("only", winner.Profile.Name);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // SweepRunAggregator.DeriveRunSeed
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeriveRunSeed_NoBaseSeed_ReturnsNull()
+    {
+        Assert.Null(SweepRunAggregator.DeriveRunSeed(null, 0));
+        Assert.Null(SweepRunAggregator.DeriveRunSeed(null, 2));
+    }
+
+    [Fact]
+    public void DeriveRunSeed_WithBaseSeed_OffsetsByRunIndex()
+    {
+        Assert.Equal(42, SweepRunAggregator.DeriveRunSeed(42, 0));
+        Assert.Equal(43, SweepRunAggregator.DeriveRunSeed(42, 1));
+        Assert.Equal(44, SweepRunAggregator.DeriveRunSeed(42, 2));
+    }
+
+    [Fact]
+    public void DeriveRunSeed_DifferentRuns_ProduceDifferentSeeds()
+    {
+        var distinctCount = Enumerable.Range(0, 5)
+            .Select(i => SweepRunAggregator.DeriveRunSeed(100, i))
+            .Distinct()
+            .Count();
+        Assert.Equal(5, distinctCount);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // SweepEntry computed properties
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SweepEntry_MeanScore_ReflectsAllRuns()
+    {
+        var entry = MakeSweepEntry(MakeProfile("test"), 60.0, 80.0, 100.0);
+        Assert.Equal(80.0, entry.MeanScore, precision: 6);
+    }
+
+    [Fact]
+    public void SweepEntry_AverageScore_IsAliasForMeanScore()
+    {
+        var entry = MakeSweepEntry(MakeProfile("test"), 55.0, 85.0);
+        Assert.Equal(entry.MeanScore, entry.AverageScore);
+    }
+
+    [Fact]
+    public void SweepEntry_Results_IsFirstRun()
+    {
+        var firstResult = MakeResult(42.0);
+        var allRuns = new List<IReadOnlyList<ModelEvalResult>>
+        {
+            new List<ModelEvalResult> { firstResult },
+            Run(90.0)
+        };
+
+        var entry = new SweepEntry
+        {
+            Profile = MakeProfile("test"),
+            Results = allRuns[0],
+            AllRunResults = allRuns
+        };
+
+        Assert.Same(firstResult, entry.Results[0]);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────
+
+    private static ModelEvalResult MakeResult(double score, string agentName = "test-agent") =>
+        new()
+        {
+            ModelName = "test-model",
+            AgentName = agentName,
+            ToolSelectionScore = score,
+            ToolSuccessScore = score,
+            ToolEfficiencyScore = score,
+            TaskCompletionScore = score,
+            OverallScore = score,
+            TestCaseCount = 1,
+            PassedCount = 1,
+            Performance = ModelPerformanceSummary.FromSnapshots("test-model", new List<PerformanceSnapshot>()),
+            TestCaseResults = new List<TestCaseResult>()
+        };
+
+    private static ModelParameterProfile MakeProfile(string name) =>
+        new() { Name = name };
+
+    private static IReadOnlyList<ModelEvalResult> Run(double score) =>
+        new List<ModelEvalResult> { MakeResult(score) };
+
+    private static List<IReadOnlyList<ModelEvalResult>> Runs(params IReadOnlyList<ModelEvalResult>[] runs) =>
+        new List<IReadOnlyList<ModelEvalResult>>(runs);
+
+    /// <summary>
+    /// Creates a SweepEntry where each score becomes a single-agent run.
+    /// The first run populates Results; all runs populate AllRunResults.
+    /// </summary>
+    private static SweepEntry MakeSweepEntry(ModelParameterProfile profile, params double[] runScores)
+    {
+        var allRuns = runScores
+            .Select(score => (IReadOnlyList<ModelEvalResult>)new List<ModelEvalResult> { MakeResult(score) })
+            .ToList();
+
+        return new SweepEntry
+        {
+            Profile = profile,
+            Results = allRuns[0],
+            AllRunResults = allRuns
+        };
+    }
+}

--- a/lucia.EvalHarness.Tests/ParameterSweepAggregationTests.cs
+++ b/lucia.EvalHarness.Tests/ParameterSweepAggregationTests.cs
@@ -70,6 +70,32 @@ public sealed class ParameterSweepAggregationTests
     }
 
     // ──────────────────────────────────────────────────────────────
+    // SweepRunAggregator.ComputeMinRunMean
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeMinRunMean_ReturnsZero_WhenNoRuns()
+    {
+        var minMean = SweepRunAggregator.ComputeMinRunMean(new List<IReadOnlyList<ModelEvalResult>>());
+        Assert.Equal(0.0, minMean);
+    }
+
+    [Fact]
+    public void ComputeMinRunMean_SingleRun_ReturnsRunMean()
+    {
+        var minMean = SweepRunAggregator.ComputeMinRunMean(Runs(Run(73.0)));
+        Assert.Equal(73.0, minMean, precision: 6);
+    }
+
+    [Fact]
+    public void ComputeMinRunMean_MultipleRuns_ReturnsLowestPerRunMean()
+    {
+        // 3 runs with means 60, 80, 100 — min is 60
+        var minMean = SweepRunAggregator.ComputeMinRunMean(Runs(Run(100.0), Run(60.0), Run(80.0)));
+        Assert.Equal(60.0, minMean, precision: 6);
+    }
+
+    // ──────────────────────────────────────────────────────────────
     // SweepRunAggregator.ComputeVariance
     // ──────────────────────────────────────────────────────────────
 

--- a/lucia.EvalHarness.Tests/ParameterSweepRunnerTests.cs
+++ b/lucia.EvalHarness.Tests/ParameterSweepRunnerTests.cs
@@ -1,0 +1,279 @@
+using lucia.EvalHarness.Configuration;
+using lucia.EvalHarness.Evaluation;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Provider-free tests for ParameterSweepRunner.RunAsync using the injectable
+/// evaluation backend constructor. Verifies that each combination is run N times,
+/// that the per-run profile (including seed offset) is propagated to the backend,
+/// and that the baseline is also run N times before deltas are computed.
+/// </summary>
+public sealed class ParameterSweepRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_EachCombination_IsEvaluatedNTimes()
+    {
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            // Use a minimal grid: 1 temp × 1 topK × 1 topP × 1 repeat = 1 combo
+            TemperatureValues = [0.5],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        // 3 baseline runs + 1 combo × 3 runs = 6 total calls
+        var baselineCalls = callLog.Where(c => c.ModelName == "baseline-model").ToList();
+        var targetCalls = callLog.Where(c => c.ModelName == "target-model").ToList();
+
+        Assert.Equal(3, baselineCalls.Count);
+        Assert.Equal(3, targetCalls.Count);
+    }
+
+    [Fact]
+    public async Task RunAsync_TwoCombinations_EachEvaluatedNTimes()
+    {
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 2,
+            TemperatureValues = [0.3, 0.7],    // 2 temps
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        // 2 baseline runs + 2 combos × 2 runs = 6 total
+        Assert.Equal(6, callLog.Count);
+
+        var targetCalls = callLog.Where(c => c.ModelName == "target-model").ToList();
+        Assert.Equal(4, targetCalls.Count);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithBaseSeed_RunsWithinComboHaveDistinctSeeds()
+    {
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            BaseSeed = 100,
+            TemperatureValues = [0.5],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        var targetCalls = callLog.Where(c => c.ModelName == "target-model").ToList();
+        Assert.Equal(3, targetCalls.Count);
+
+        // Each run within the same combination must have a distinct seed
+        var seeds = targetCalls.Select(c => c.Profile.Seed).ToList();
+        Assert.All(seeds, s => Assert.NotNull(s));
+        Assert.Equal(3, seeds.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task RunAsync_WithBaseSeed_DifferentCombosHaveNonOverlappingSeedBlocks()
+    {
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            BaseSeed = 1000,
+            TemperatureValues = [0.3, 0.7],   // 2 combos
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        var targetCalls = callLog.Where(c => c.ModelName == "target-model").ToList();
+        Assert.Equal(6, targetCalls.Count); // 2 combos × 3 runs
+
+        // All 6 target runs must have distinct seeds (no block overlap between combos)
+        var seeds = targetCalls.Select(c => c.Profile.Seed).ToList();
+        Assert.All(seeds, s => Assert.NotNull(s));
+        Assert.Equal(6, seeds.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task RunAsync_WithoutBaseSeed_ProfileSeedsAreNull()
+    {
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 2,
+            BaseSeed = null,  // no seed
+            TemperatureValues = [0.5],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        var targetCalls = callLog.Where(c => c.ModelName == "target-model").ToList();
+        Assert.All(targetCalls, c => Assert.Null(c.Profile.Seed));
+    }
+
+    [Fact]
+    public async Task RunAsync_BaselineMeanScore_IsAggregatedAcrossAllBaselineRuns()
+    {
+        // Each baseline call returns a different score so we can verify mean, not
+        // just a single-run value.
+        var callCount = 0;
+        var scores = new[] { 60.0, 80.0, 100.0 };  // mean = 80
+
+        Func<string, ModelParameterProfile, CancellationToken, Task<IReadOnlyList<ModelEvalResult>>> backend =
+            (_, _, _) =>
+            {
+                var score = scores[callCount % scores.Length];
+                callCount++;
+                return Task.FromResult<IReadOnlyList<ModelEvalResult>>(
+                    new List<ModelEvalResult> { MakeResult(score) });
+            };
+
+        var runner = new ParameterSweepRunner(backend);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            TemperatureValues = [0.5],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        // The first 3 calls are baseline (scores 60, 80, 100 → mean=80)
+        var result = await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        Assert.Equal(80.0, result.BaselineMeanScore, precision: 6);
+    }
+
+    [Fact]
+    public async Task RunAsync_WinnerSelection_UsesMeanNotSingleRun()
+    {
+        // Backend returns low scores for combo 0 and consistent high scores for combo 1
+        var scoreMap = new Dictionary<int, double>
+        {
+            [0] = 90.0,  // combo-0 first run: noisy high
+            [1] = 50.0,  // combo-0 second run: low
+            [2] = 50.0,  // combo-0 third run: low  → mean = 63.3
+            [3] = 75.0,  // combo-1 first run
+            [4] = 75.0,  // combo-1 second run
+            [5] = 75.0   // combo-1 third run → mean = 75 → should win
+        };
+
+        var callIndex = 0;
+        Func<string, ModelParameterProfile, CancellationToken, Task<IReadOnlyList<ModelEvalResult>>> backend =
+            (modelName, _, _) =>
+            {
+                double score;
+                if (modelName == "target-model")
+                {
+                    score = scoreMap[callIndex++];
+                }
+                else
+                {
+                    score = 70.0; // baseline (doesn't matter here)
+                }
+                return Task.FromResult<IReadOnlyList<ModelEvalResult>>(
+                    new List<ModelEvalResult> { MakeResult(score) });
+            };
+
+        var runner = new ParameterSweepRunner(backend);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            TemperatureValues = [0.3, 0.7],  // exactly 2 combos
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        var result = await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+        var entries = result.TargetResults["target-model"].ToList();
+
+        // Combo 0 mean = (90+50+50)/3 = 63.3, combo 1 mean = 75 → combo 1 should win
+        var winner = SweepRunAggregator.SelectWinner(entries);
+        Assert.Equal(75.0, winner.MeanScore, precision: 1);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────
+
+    private static ParameterSweepRunner MakeRunner(
+        List<(string ModelName, ModelParameterProfile Profile)> callLog,
+        double score)
+    {
+        return new ParameterSweepRunner((modelName, profile, _) =>
+        {
+            callLog.Add((modelName, profile));
+            return Task.FromResult<IReadOnlyList<ModelEvalResult>>(
+                new List<ModelEvalResult> { MakeResult(score) });
+        });
+    }
+
+    private static Task<SweepResult> RunSweepAsync(
+        ParameterSweepRunner runner,
+        ParameterSweepConfig config,
+        string baselineModel,
+        IReadOnlyList<string> targetModels)
+    {
+        return runner.RunAsync(
+            baselineModel,
+            targetModels,
+            agentNames: [],
+            sweepConfig: config,
+            testCaseLoader: _ => new List<AgentEval.Models.TestCase>(),
+            maxCasesPerAgent: null);
+    }
+
+    private static ModelEvalResult MakeResult(double score) =>
+        new()
+        {
+            ModelName = "test-model",
+            AgentName = "test-agent",
+            ToolSelectionScore = score,
+            ToolSuccessScore = score,
+            ToolEfficiencyScore = score,
+            TaskCompletionScore = score,
+            OverallScore = score,
+            TestCaseCount = 1,
+            PassedCount = 1,
+            Performance = ModelPerformanceSummary.FromSnapshots("test-model", new List<PerformanceSnapshot>()),
+            TestCaseResults = new List<TestCaseResult>()
+        };
+}

--- a/lucia.EvalHarness.Tests/ParameterSweepRunnerTests.cs
+++ b/lucia.EvalHarness.Tests/ParameterSweepRunnerTests.cs
@@ -230,6 +230,80 @@ public sealed class ParameterSweepRunnerTests
         Assert.Equal(75.0, winner.MeanScore, precision: 1);
     }
 
+    [Fact]
+    public async Task RunAsync_WithBaseSeed_PerRunSeedsMatchDerivedFormula()
+    {
+        // Combo 0, BaseSeed=1000, N=3:
+        //   GenerateCombinations stamps profile.Seed = 1000 + 0 * 3 = 1000
+        //   DeriveRunSeed(1000, 0) = 1000, DeriveRunSeed(1000, 1) = 1001, DeriveRunSeed(1000, 2) = 1002
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            BaseSeed = 1000,
+            TemperatureValues = [0.5],   // single combo → comboIndex = 0
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        // Runs within a single combo are sequential, so callLog order is stable
+        var targetSeeds = callLog
+            .Where(c => c.ModelName == "target-model")
+            .Select(c => c.Profile.Seed)
+            .ToList();
+
+        Assert.Equal(3, targetSeeds.Count);
+        Assert.Equal(1000, targetSeeds[0]);
+        Assert.Equal(1001, targetSeeds[1]);
+        Assert.Equal(1002, targetSeeds[2]);
+    }
+
+    [Fact]
+    public async Task RunAsync_TwoCombinations_SeedBlocksDoNotOverlap()
+    {
+        // With 2 combos, N=3, BaseSeed=1000:
+        //   Combo 0 profile.Seed = 1000 + 0*3 = 1000  → run seeds {1000, 1001, 1002}
+        //   Combo 1 profile.Seed = 1000 + 1*3 = 1003  → run seeds {1003, 1004, 1005}
+        var callLog = new List<(string ModelName, ModelParameterProfile Profile)>();
+        var runner = MakeRunner(callLog, score: 70.0);
+
+        var config = new ParameterSweepConfig
+        {
+            RunsPerCombination = 3,
+            BaseSeed = 1000,
+            TemperatureValues = [0.3, 0.7],   // 2 combos
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
+
+        var targetSeeds = callLog
+            .Where(c => c.ModelName == "target-model")
+            .Select(c => c.Profile.Seed)
+            .Where(s => s.HasValue)
+            .Select(s => s!.Value)
+            .ToList();
+
+        // 6 seeds total, all distinct, each block of 3 must not overlap the other
+        Assert.Equal(6, targetSeeds.Count);
+        Assert.Equal(6, targetSeeds.Distinct().Count());
+
+        // The two blocks must be {1000,1001,1002} and {1003,1004,1005} (any order between blocks)
+        var seedSet = targetSeeds.ToHashSet();
+        Assert.True(seedSet.IsSupersetOf(new[] { 1000, 1001, 1002 }) ||
+                    seedSet.IsSupersetOf(new[] { 1003, 1004, 1005 }),
+                    "Seed blocks 0 and 1 should be contiguous, non-overlapping ranges");
+    }
+
     // ──────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────

--- a/lucia.EvalHarness.Tests/lucia.EvalHarness.Tests.csproj
+++ b/lucia.EvalHarness.Tests/lucia.EvalHarness.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);AIEVAL001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\lucia.EvalHarness\lucia.EvalHarness.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/lucia.EvalHarness/Configuration/ParameterSweepConfig.cs
+++ b/lucia.EvalHarness/Configuration/ParameterSweepConfig.cs
@@ -56,13 +56,24 @@ public sealed class ParameterSweepConfig
     public int RunsPerCombination { get; set; } = 3;
 
     /// <summary>
+    /// Optional base seed for deterministic sweeps. When set, each generated
+    /// combination receives <c>Seed = BaseSeed + comboIndex * RunsPerCombination</c>,
+    /// and the sweep runner offsets that by run index so every individual run is
+    /// reproducible yet distinct. When null (default), runs are non-deterministic.
+    /// </summary>
+    public int? BaseSeed { get; set; }
+
+    /// <summary>
     /// Generates the parameter combinations to test, applying <see cref="MaxCombinations"/> limit.
     /// Uses systematic sampling when the full grid is too large.
+    /// When <see cref="BaseSeed"/> is set, each profile's <see cref="ModelParameterProfile.Seed"/>
+    /// is pre-populated so the sweep runner can derive per-run seeds from it.
     /// </summary>
     public IReadOnlyList<ModelParameterProfile> GenerateCombinations()
     {
         var fullGrid = new List<ModelParameterProfile>();
         var index = 0;
+        var runsPerCombo = Math.Max(1, RunsPerCombination);
 
         foreach (var temp in TemperatureValues)
         foreach (var topK in TopKValues)
@@ -71,12 +82,17 @@ public sealed class ParameterSweepConfig
         {
             fullGrid.Add(new ModelParameterProfile
             {
-                Name = $"sweep-{index++}",
+                Name = $"sweep-{index}",
                 Temperature = temp,
                 TopK = topK,
                 TopP = topP,
-                RepeatPenalty = repeat
+                RepeatPenalty = repeat,
+                // Allocate a non-overlapping seed block per combination so that
+                // DeriveRunSeed(profile.Seed, runIndex) yields distinct seeds for
+                // every (combo, run) pair.
+                Seed = BaseSeed.HasValue ? BaseSeed.Value + index * runsPerCombo : null
             });
+            index++;
         }
 
         if (fullGrid.Count <= MaxCombinations)
@@ -86,7 +102,12 @@ public sealed class ParameterSweepConfig
         var step = (double)fullGrid.Count / MaxCombinations;
         return Enumerable.Range(0, MaxCombinations)
             .Select(i => fullGrid[(int)(i * step)])
-            .Select((p, i) => p with { Name = $"sweep-{i}" })
+            .Select((p, i) => p with
+            {
+                Name = $"sweep-{i}",
+                // Recompute seed for the sampled index so blocks stay non-overlapping
+                Seed = BaseSeed.HasValue ? BaseSeed.Value + i * runsPerCombo : null
+            })
             .ToList();
     }
 }

--- a/lucia.EvalHarness/Configuration/ParameterSweepConfig.cs
+++ b/lucia.EvalHarness/Configuration/ParameterSweepConfig.cs
@@ -47,6 +47,15 @@ public sealed class ParameterSweepConfig
     public int MaxCombinations { get; set; } = 20;
 
     /// <summary>
+    /// Number of times each combination is evaluated before selecting a winner.
+    /// Running multiple times reduces the impact of LLM non-determinism on winner
+    /// selection; the winner is chosen by mean score across all runs, with score
+    /// variance used as a tie-breaker (lower variance wins).
+    /// Default: 3. Set to 1 to restore the old single-run behaviour.
+    /// </summary>
+    public int RunsPerCombination { get; set; } = 3;
+
+    /// <summary>
     /// Generates the parameter combinations to test, applying <see cref="MaxCombinations"/> limit.
     /// Uses systematic sampling when the full grid is too large.
     /// </summary>

--- a/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
+++ b/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
@@ -15,13 +15,19 @@ public sealed class SweepResult
     public required DateTimeOffset CompletedAt { get; init; }
 
     /// <summary>
-    /// The baseline model's evaluation results (benchmark target).
+    /// The baseline model''s evaluation results from the first run (display use).
     /// </summary>
     public required IReadOnlyList<ModelEvalResult> BaselineResults { get; init; }
 
     /// <summary>
+    /// Mean score across all N baseline runs. Use this for mean-to-mean delta
+    /// comparisons instead of deriving it from the single first-run BaselineResults.
+    /// </summary>
+    public required double BaselineMeanScore { get; init; }
+
+    /// <summary>
     /// Results per target model, keyed by model name.
-    /// Each entry maps parameter profile name → evaluation results.
+    /// Each entry maps parameter profile name to evaluation results.
     /// </summary>
     public required IReadOnlyDictionary<string, IReadOnlyList<SweepEntry>> TargetResults { get; init; }
 }
@@ -36,12 +42,12 @@ public sealed class SweepEntry
     public required ModelParameterProfile Profile { get; init; }
 
     /// <summary>
-    /// Results from the first run only — used for per-agent display/reporting.
+    /// Results from the first run only -- used for per-agent display/reporting.
     /// </summary>
     public required IReadOnlyList<ModelEvalResult> Results { get; init; }
 
     /// <summary>
-    /// Results for every run. Each inner list contains one <see cref="ModelEvalResult"/>
+    /// Results for every run. Each inner list contains one ModelEvalResult
     /// per agent evaluated in that run.
     /// </summary>
     public required IReadOnlyList<IReadOnlyList<ModelEvalResult>> AllRunResults { get; init; }
@@ -59,12 +65,18 @@ public sealed class SweepEntry
     public double ScoreVariance => SweepRunAggregator.ComputeVariance(AllRunResults);
 
     /// <summary>
+    /// Standard deviation of per-run mean scores (sqrt of variance).
+    /// Use this for display instead of variance -- same units as the score.
+    /// </summary>
+    public double ScoreStdDev => Math.Sqrt(ScoreVariance);
+
+    /// <summary>
     /// Pessimistic bound: the lowest per-run mean score across all N runs.
     /// </summary>
     public double MinRunMean => SweepRunAggregator.ComputeMinRunMean(AllRunResults);
 
     /// <summary>
-    /// Average overall score — alias for <see cref="MeanScore"/> for backward
+    /// Average overall score -- alias for MeanScore for backward
     /// compatibility with report generators and display code.
     /// </summary>
     public double AverageScore => MeanScore;
@@ -79,12 +91,17 @@ public sealed class SweepEntry
 
 /// <summary>
 /// Orchestrates parameter sweep experiments: runs each target model at multiple
-/// parameter configurations and compares against a baseline model's scores.
+/// parameter configurations and compares against a baseline model''s scores.
 /// </summary>
 public sealed class ParameterSweepRunner
 {
     private readonly EvalRunner _evalRunner;
     private readonly RealAgentFactory _agentFactory;
+
+    // Injectable evaluation backend for testing. When non-null, replaces the
+    // real agent factory / eval runner calls for both baseline and sweep runs.
+    private readonly Func<string, ModelParameterProfile, CancellationToken,
+        Task<IReadOnlyList<ModelEvalResult>>>? _evalBackend;
 
     public ParameterSweepRunner(EvalRunner evalRunner, RealAgentFactory agentFactory)
     {
@@ -93,10 +110,24 @@ public sealed class ParameterSweepRunner
     }
 
     /// <summary>
+    /// Creates a runner with a custom evaluation backend, intended for testing or
+    /// embedding the sweep runner in scenarios where the full agent factory is
+    /// unavailable. The delegate is called once per (modelName, profile, run).
+    /// </summary>
+    public ParameterSweepRunner(
+        Func<string, ModelParameterProfile, CancellationToken, Task<IReadOnlyList<ModelEvalResult>>> evalBackend)
+    {
+        _evalRunner = null!;
+        _agentFactory = null!;
+        _evalBackend = evalBackend;
+    }
+
+    /// <summary>
     /// Runs a baseline evaluation with the best/largest model, then sweeps
     /// parameter configurations for each target model.
-    /// Each combination is evaluated <see cref="ParameterSweepConfig.RunsPerCombination"/> times
-    /// and the winner is chosen by mean score across all runs.
+    /// Both baseline and each combination are evaluated RunsPerCombination times;
+    /// the winner is chosen by mean score across all runs, with variance as a
+    /// tie-breaker. Deltas are mean-to-mean to avoid single-run baseline noise.
     /// </summary>
     public async Task<SweepResult> RunAsync(
         string baselineModel,
@@ -111,15 +142,28 @@ public sealed class ParameterSweepRunner
         var combinations = sweepConfig.GenerateCombinations();
         var runsPerCombination = Math.Max(1, sweepConfig.RunsPerCombination);
 
-        // 1. Run baseline with default parameters
-        AnsiConsole.MarkupLine($"[bold]Running baseline:[/] {Markup.Escape(baselineModel)} (default parameters)");
+        // 1. Run baseline N times so baseline noise matches sweep noise
+        AnsiConsole.MarkupLine(
+            $"[bold]Running baseline:[/] {Markup.Escape(baselineModel)} " +
+            $"(default parameters, {runsPerCombination} run{(runsPerCombination == 1 ? "" : "s")})");
 
-        _agentFactory.ParameterProfile = ModelParameterProfile.Default;
-        var baselineResults = await RunModelAcrossAgentsAsync(
-            baselineModel, agentNames, testCaseLoader, maxCasesPerAgent, ModelParameterProfile.Default, ct);
+        var baselineAllRuns = new List<IReadOnlyList<ModelEvalResult>>(runsPerCombination);
+        for (var runIndex = 0; runIndex < runsPerCombination; runIndex++)
+        {
+            // Derive a seed for each baseline run when BaseSeed is configured
+            var baselineRunProfile = sweepConfig.BaseSeed.HasValue
+                ? ModelParameterProfile.Default with
+                  { Seed = SweepRunAggregator.DeriveRunSeed(sweepConfig.BaseSeed, runIndex) }
+                : ModelParameterProfile.Default;
 
-        var baselineAvg = baselineResults.Average(r => r.OverallScore);
-        AnsiConsole.MarkupLine($"[green]\u2713[/] Baseline score: {baselineAvg:F1}");
+            var run = await EvalAsync(baselineModel, agentNames, testCaseLoader,
+                maxCasesPerAgent, baselineRunProfile, ct);
+            baselineAllRuns.Add(run);
+        }
+
+        var baselineResults = baselineAllRuns[0]; // first run for per-agent display
+        var baselineMeanScore = SweepRunAggregator.ComputeMean(baselineAllRuns);
+        AnsiConsole.MarkupLine($"[green]\u2713[/] Baseline mean score: {baselineMeanScore:F1}");
         AnsiConsole.WriteLine();
 
         // 2. Sweep each target model
@@ -129,7 +173,7 @@ public sealed class ParameterSweepRunner
         {
             AnsiConsole.MarkupLine(
                 $"[bold]Sweeping:[/] {Markup.Escape(targetModel)} " +
-                $"({combinations.Count} configurations × {runsPerCombination} run{(runsPerCombination == 1 ? "" : "s")} each)");
+                $"({combinations.Count} configurations x {runsPerCombination} run{(runsPerCombination == 1 ? "" : "s")} each)");
 
             var entries = new List<SweepEntry>();
 
@@ -152,14 +196,17 @@ public sealed class ParameterSweepRunner
 
                         for (var runIndex = 0; runIndex < runsPerCombination; runIndex++)
                         {
-                            // Derive a per-run seed so each run is reproducible yet distinct
+                            // profile.Seed is already set by GenerateCombinations() when BaseSeed
+                            // is configured; DeriveRunSeed offsets it by runIndex so each run gets
+                            // a unique, reproducible seed within the combination''s allocated block.
                             var runProfile = profile.Seed.HasValue
                                 ? profile with { Seed = SweepRunAggregator.DeriveRunSeed(profile.Seed, runIndex) }
                                 : profile;
 
-                            _agentFactory.ParameterProfile = runProfile;
+                            if (_evalBackend is null)
+                                _agentFactory.ParameterProfile = runProfile;
 
-                            var runResults = await RunModelAcrossAgentsAsync(
+                            var runResults = await EvalAsync(
                                 targetModel, agentNames, testCaseLoader, maxCasesPerAgent, runProfile, ct);
 
                             allRunResults.Add(runResults);
@@ -168,7 +215,7 @@ public sealed class ParameterSweepRunner
                         entries.Add(new SweepEntry
                         {
                             Profile = profile,
-                            Results = allRunResults[0],  // first run — used for per-agent display
+                            Results = allRunResults[0],  // first run -- used for per-agent display
                             AllRunResults = allRunResults
                         });
 
@@ -178,9 +225,9 @@ public sealed class ParameterSweepRunner
 
             var bestEntry = SweepRunAggregator.SelectWinner(entries);
             AnsiConsole.MarkupLine(
-                $"[green]\u2713[/] Best config: {Markup.Escape(bestEntry.Profile.ToSummary())} → " +
-                $"{bestEntry.MeanScore:F1} (±{bestEntry.ScoreVariance:F2} var, " +
-                $"{runsPerCombination}-run mean, delta from baseline: {bestEntry.MeanScore - baselineAvg:+0.0;-0.0})");
+                $"[green]\u2713[/] Best config: {Markup.Escape(bestEntry.Profile.ToSummary())} -> " +
+                $"{bestEntry.MeanScore:F1} (σ={bestEntry.ScoreStdDev:F2}, " +
+                $"{runsPerCombination}-run mean, delta from baseline: {bestEntry.MeanScore - baselineMeanScore:+0.0;-0.0})");
             AnsiConsole.WriteLine();
 
             targetResults[targetModel] = entries;
@@ -192,8 +239,24 @@ public sealed class ParameterSweepRunner
             StartedAt = startedAt,
             CompletedAt = DateTimeOffset.UtcNow,
             BaselineResults = baselineResults,
+            BaselineMeanScore = baselineMeanScore,
             TargetResults = targetResults
         };
+    }
+
+    // Dispatches to either the injectable backend (tests) or the real agent factory + eval runner.
+    private async Task<IReadOnlyList<ModelEvalResult>> EvalAsync(
+        string modelName,
+        IReadOnlyList<string> agentNames,
+        Func<string, IReadOnlyList<AgentEval.Models.TestCase>> testCaseLoader,
+        int? maxCasesPerAgent,
+        ModelParameterProfile profile,
+        CancellationToken ct)
+    {
+        if (_evalBackend is not null)
+            return await _evalBackend(modelName, profile, ct);
+
+        return await RunModelAcrossAgentsAsync(modelName, agentNames, testCaseLoader, maxCasesPerAgent, profile, ct);
     }
 
     private async Task<IReadOnlyList<ModelEvalResult>> RunModelAcrossAgentsAsync(

--- a/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
+++ b/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
@@ -15,7 +15,7 @@ public sealed class SweepResult
     public required DateTimeOffset CompletedAt { get; init; }
 
     /// <summary>
-    /// The baseline model''s evaluation results from the first run (display use).
+    /// The baseline model's evaluation results from the first run (display use).
     /// </summary>
     public required IReadOnlyList<ModelEvalResult> BaselineResults { get; init; }
 
@@ -91,7 +91,7 @@ public sealed class SweepEntry
 
 /// <summary>
 /// Orchestrates parameter sweep experiments: runs each target model at multiple
-/// parameter configurations and compares against a baseline model''s scores.
+/// parameter configurations and compares against a baseline model's scores.
 /// </summary>
 public sealed class ParameterSweepRunner
 {
@@ -198,7 +198,7 @@ public sealed class ParameterSweepRunner
                         {
                             // profile.Seed is already set by GenerateCombinations() when BaseSeed
                             // is configured; DeriveRunSeed offsets it by runIndex so each run gets
-                            // a unique, reproducible seed within the combination''s allocated block.
+                            // a unique, reproducible seed within the combination's allocated block.
                             var runProfile = profile.Seed.HasValue
                                 ? profile with { Seed = SweepRunAggregator.DeriveRunSeed(profile.Seed, runIndex) }
                                 : profile;

--- a/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
+++ b/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
@@ -82,11 +82,18 @@ public sealed class SweepEntry
     public double AverageScore => MeanScore;
 
     /// <summary>
-    /// Average latency in milliseconds from the first run (representative sample).
+    /// Mean latency in milliseconds averaged across all N runs and all agents.
     /// </summary>
-    public double AverageLatencyMs => Results.Count > 0
-        ? Results.Average(r => r.Performance.MeanLatency.TotalMilliseconds)
-        : 0;
+    public double AverageLatencyMs
+    {
+        get
+        {
+            var all = AllRunResults.SelectMany(run => run).ToList();
+            return all.Count > 0
+                ? all.Average(r => r.Performance.MeanLatency.TotalMilliseconds)
+                : 0;
+        }
+    }
 }
 
 /// <summary>

--- a/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
+++ b/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
@@ -27,22 +27,50 @@ public sealed class SweepResult
 }
 
 /// <summary>
-/// A single sweep entry: one model evaluated with a specific parameter profile.
+/// A single sweep entry: one model evaluated with a specific parameter profile
+/// across N independent runs. Scores are aggregated over all runs to reduce
+/// the effect of LLM non-determinism on winner selection.
 /// </summary>
 public sealed class SweepEntry
 {
     public required ModelParameterProfile Profile { get; init; }
+
+    /// <summary>
+    /// Results from the first run only — used for per-agent display/reporting.
+    /// </summary>
     public required IReadOnlyList<ModelEvalResult> Results { get; init; }
 
     /// <summary>
-    /// Average overall score across all agents for this profile.
+    /// Results for every run. Each inner list contains one <see cref="ModelEvalResult"/>
+    /// per agent evaluated in that run.
     /// </summary>
-    public double AverageScore => Results.Count > 0
-        ? Results.Average(r => r.OverallScore)
-        : 0;
+    public required IReadOnlyList<IReadOnlyList<ModelEvalResult>> AllRunResults { get; init; }
 
     /// <summary>
-    /// Average latency in milliseconds across all agents.
+    /// Mean overall score across all runs and all agents.
+    /// This is the primary metric used for winner selection.
+    /// </summary>
+    public double MeanScore => SweepRunAggregator.ComputeMean(AllRunResults);
+
+    /// <summary>
+    /// Variance of per-run mean scores. Lower value means the combination is
+    /// stable; higher value means results are noisy.
+    /// </summary>
+    public double ScoreVariance => SweepRunAggregator.ComputeVariance(AllRunResults);
+
+    /// <summary>
+    /// Pessimistic bound: the lowest per-run mean score across all N runs.
+    /// </summary>
+    public double MinRunMean => SweepRunAggregator.ComputeMinRunMean(AllRunResults);
+
+    /// <summary>
+    /// Average overall score — alias for <see cref="MeanScore"/> for backward
+    /// compatibility with report generators and display code.
+    /// </summary>
+    public double AverageScore => MeanScore;
+
+    /// <summary>
+    /// Average latency in milliseconds from the first run (representative sample).
     /// </summary>
     public double AverageLatencyMs => Results.Count > 0
         ? Results.Average(r => r.Performance.MeanLatency.TotalMilliseconds)
@@ -67,6 +95,8 @@ public sealed class ParameterSweepRunner
     /// <summary>
     /// Runs a baseline evaluation with the best/largest model, then sweeps
     /// parameter configurations for each target model.
+    /// Each combination is evaluated <see cref="ParameterSweepConfig.RunsPerCombination"/> times
+    /// and the winner is chosen by mean score across all runs.
     /// </summary>
     public async Task<SweepResult> RunAsync(
         string baselineModel,
@@ -79,6 +109,7 @@ public sealed class ParameterSweepRunner
     {
         var startedAt = DateTimeOffset.UtcNow;
         var combinations = sweepConfig.GenerateCombinations();
+        var runsPerCombination = Math.Max(1, sweepConfig.RunsPerCombination);
 
         // 1. Run baseline with default parameters
         AnsiConsole.MarkupLine($"[bold]Running baseline:[/] {Markup.Escape(baselineModel)} (default parameters)");
@@ -96,7 +127,9 @@ public sealed class ParameterSweepRunner
 
         foreach (var targetModel in targetModels)
         {
-            AnsiConsole.MarkupLine($"[bold]Sweeping:[/] {Markup.Escape(targetModel)} ({combinations.Count} parameter configurations)");
+            AnsiConsole.MarkupLine(
+                $"[bold]Sweeping:[/] {Markup.Escape(targetModel)} " +
+                $"({combinations.Count} configurations × {runsPerCombination} run{(runsPerCombination == 1 ? "" : "s")} each)");
 
             var entries = new List<SweepEntry>();
 
@@ -115,25 +148,39 @@ public sealed class ParameterSweepRunner
 
                     foreach (var profile in combinations)
                     {
-                        _agentFactory.ParameterProfile = profile;
+                        var allRunResults = new List<IReadOnlyList<ModelEvalResult>>(runsPerCombination);
 
-                        var results = await RunModelAcrossAgentsAsync(
-                            targetModel, agentNames, testCaseLoader, maxCasesPerAgent, profile, ct);
+                        for (var runIndex = 0; runIndex < runsPerCombination; runIndex++)
+                        {
+                            // Derive a per-run seed so each run is reproducible yet distinct
+                            var runProfile = profile.Seed.HasValue
+                                ? profile with { Seed = SweepRunAggregator.DeriveRunSeed(profile.Seed, runIndex) }
+                                : profile;
+
+                            _agentFactory.ParameterProfile = runProfile;
+
+                            var runResults = await RunModelAcrossAgentsAsync(
+                                targetModel, agentNames, testCaseLoader, maxCasesPerAgent, runProfile, ct);
+
+                            allRunResults.Add(runResults);
+                        }
 
                         entries.Add(new SweepEntry
                         {
                             Profile = profile,
-                            Results = results
+                            Results = allRunResults[0],  // first run — used for per-agent display
+                            AllRunResults = allRunResults
                         });
 
                         progressTask.Increment(1);
                     }
                 });
 
-            var bestEntry = entries.OrderByDescending(e => e.AverageScore).First();
+            var bestEntry = SweepRunAggregator.SelectWinner(entries);
             AnsiConsole.MarkupLine(
-                $"[green]\u2713[/] Best config: {Markup.Escape(bestEntry.Profile.ToSummary())} → {bestEntry.AverageScore:F1} " +
-                $"(delta from baseline: {bestEntry.AverageScore - baselineAvg:+0.0;-0.0})");
+                $"[green]\u2713[/] Best config: {Markup.Escape(bestEntry.Profile.ToSummary())} → " +
+                $"{bestEntry.MeanScore:F1} (±{bestEntry.ScoreVariance:F2} var, " +
+                $"{runsPerCombination}-run mean, delta from baseline: {bestEntry.MeanScore - baselineAvg:+0.0;-0.0})");
             AnsiConsole.WriteLine();
 
             targetResults[targetModel] = entries;

--- a/lucia.EvalHarness/Evaluation/SweepRunAggregator.cs
+++ b/lucia.EvalHarness/Evaluation/SweepRunAggregator.cs
@@ -1,0 +1,67 @@
+namespace lucia.EvalHarness.Evaluation;
+
+/// <summary>
+/// Pure aggregation helpers for multi-run parameter sweep results.
+/// Each combination is evaluated N times; these methods compute the statistics
+/// that drive winner selection and report generation.
+/// </summary>
+public static class SweepRunAggregator
+{
+    /// <summary>
+    /// Computes the overall mean score across all runs and all agents.
+    /// </summary>
+    public static double ComputeMean(IReadOnlyList<IReadOnlyList<ModelEvalResult>> allRunResults)
+    {
+        var all = allRunResults.SelectMany(run => run).ToList();
+        return all.Count > 0 ? all.Average(r => r.OverallScore) : 0.0;
+    }
+
+    /// <summary>
+    /// Computes the variance of per-run mean scores.
+    /// Low variance indicates the combination is stable; high variance means
+    /// the result is noisy and the mean is less trustworthy.
+    /// </summary>
+    public static double ComputeVariance(IReadOnlyList<IReadOnlyList<ModelEvalResult>> allRunResults)
+    {
+        if (allRunResults.Count < 2)
+            return 0.0;
+
+        var runMeans = allRunResults
+            .Select(run => run.Count > 0 ? run.Average(r => r.OverallScore) : 0.0)
+            .ToList();
+
+        var mean = runMeans.Average();
+        return runMeans.Average(m => (m - mean) * (m - mean));
+    }
+
+    /// <summary>
+    /// Returns the lowest per-run mean score — the pessimistic bound.
+    /// </summary>
+    public static double ComputeMinRunMean(IReadOnlyList<IReadOnlyList<ModelEvalResult>> allRunResults)
+    {
+        if (allRunResults.Count == 0)
+            return 0.0;
+
+        return allRunResults
+            .Select(run => run.Count > 0 ? run.Average(r => r.OverallScore) : 0.0)
+            .Min();
+    }
+
+    /// <summary>
+    /// Selects the winning entry from a list of sweep entries.
+    /// Primary criterion: highest mean score across N runs.
+    /// Tie-breaker: lower score variance (more stable combination wins).
+    /// </summary>
+    public static SweepEntry SelectWinner(IReadOnlyList<SweepEntry> entries) =>
+        entries
+            .OrderByDescending(e => e.MeanScore)
+            .ThenBy(e => e.ScoreVariance)
+            .First();
+
+    /// <summary>
+    /// Derives a per-run seed from a base seed so each run is reproducible
+    /// yet distinct. Returns <see langword="null"/> when no base seed is set.
+    /// </summary>
+    public static int? DeriveRunSeed(int? baseSeed, int runIndex) =>
+        baseSeed.HasValue ? baseSeed.Value + runIndex : null;
+}

--- a/lucia.EvalHarness/Reports/SweepReportGenerator.cs
+++ b/lucia.EvalHarness/Reports/SweepReportGenerator.cs
@@ -147,30 +147,8 @@ public static class SweepReportGenerator
         targets = result.TargetResults.Select(kvp => new
         {
             model = kvp.Key,
-            // Use SelectWinner so the JSON best-config matches what the runner chose
-            bestConfig = kvp.Value
-                .OrderByDescending(e => e.MeanScore)
-                .ThenBy(e => e.ScoreVariance)
-                .Select(e => new
-                {
-                    parameters = new
-                    {
-                        e.Profile.Name,
-                        e.Profile.Temperature,
-                        e.Profile.TopK,
-                        e.Profile.TopP,
-                        e.Profile.RepeatPenalty
-                    },
-                    // Emit both averageScore (backward compat) and meanScore (new)
-                    averageScore = e.AverageScore,
-                    meanScore = e.MeanScore,
-                    scoreVariance = e.ScoreVariance,
-                    scoreStdDev = e.ScoreStdDev,
-                    minRunMean = e.MinRunMean,
-                    runCount = e.AllRunResults.Count,
-                    averageLatencyMs = e.AverageLatencyMs,
-                    agents = e.Results.Select(r => new { r.AgentName, r.OverallScore })
-                }).FirstOrDefault(),
+            // Use SelectWinner so bestConfig exactly matches what the runner chose
+            bestConfig = BuildBestConfigJson(kvp.Value),
             allConfigs = kvp.Value.OrderByDescending(e => e.MeanScore).ThenBy(e => e.ScoreVariance).Select(e => new
             {
                 parameters = new
@@ -190,4 +168,36 @@ public static class SweepReportGenerator
             })
         })
     };
+
+    /// <summary>
+    /// Projects the winning <see cref="SweepEntry"/> (chosen via
+    /// <see cref="SweepRunAggregator.SelectWinner"/>) into the JSON bestConfig shape.
+    /// Returns null for an empty entry list so the JSON field is omitted.
+    /// </summary>
+    private static object? BuildBestConfigJson(IReadOnlyList<SweepEntry> entries)
+    {
+        if (entries.Count == 0) return null;
+
+        var w = SweepRunAggregator.SelectWinner(entries);
+        return new
+        {
+            parameters = new
+            {
+                w.Profile.Name,
+                w.Profile.Temperature,
+                w.Profile.TopK,
+                w.Profile.TopP,
+                w.Profile.RepeatPenalty
+            },
+            // Emit both averageScore (backward compat) and meanScore (new)
+            averageScore = w.AverageScore,
+            meanScore = w.MeanScore,
+            scoreVariance = w.ScoreVariance,
+            scoreStdDev = w.ScoreStdDev,
+            minRunMean = w.MinRunMean,
+            runCount = w.AllRunResults.Count,
+            averageLatencyMs = w.AverageLatencyMs,
+            agents = w.Results.Select(r => new { r.AgentName, r.OverallScore })
+        };
+    }
 }

--- a/lucia.EvalHarness/Reports/SweepReportGenerator.cs
+++ b/lucia.EvalHarness/Reports/SweepReportGenerator.cs
@@ -72,26 +72,26 @@ public static class SweepReportGenerator
             sb.AppendLine();
 
             // Summary: best configuration
-            var bestEntry = entries.OrderByDescending(e => e.AverageScore).First();
-            var worstEntry = entries.OrderBy(e => e.AverageScore).First();
-            sb.AppendLine($"- **Best config:** {bestEntry.Profile.ToSummary()} → **{bestEntry.AverageScore:F1}** (Δ from baseline: {bestEntry.AverageScore - baselineAvg:+0.0;-0.0})");
-            sb.AppendLine($"- **Worst config:** {worstEntry.Profile.ToSummary()} → **{worstEntry.AverageScore:F1}**");
-            sb.AppendLine($"- **Score range:** {worstEntry.AverageScore:F1} – {bestEntry.AverageScore:F1}");
+            var bestEntry = entries.OrderByDescending(e => e.MeanScore).First();
+            var worstEntry = entries.OrderBy(e => e.MeanScore).First();
+            sb.AppendLine($"- **Best config:** {bestEntry.Profile.ToSummary()} → **{bestEntry.MeanScore:F1}** (Δ from baseline: {bestEntry.MeanScore - baselineAvg:+0.0;-0.0}, var: {bestEntry.ScoreVariance:F2})");
+            sb.AppendLine($"- **Worst config:** {worstEntry.Profile.ToSummary()} → **{worstEntry.MeanScore:F1}**");
+            sb.AppendLine($"- **Score range:** {worstEntry.MeanScore:F1} – {bestEntry.MeanScore:F1}");
             sb.AppendLine();
 
             // Full results table
-            sb.AppendLine("| # | Temperature | Top-K | Top-P | Repeat | Avg Score | Δ Baseline | Avg Latency |");
-            sb.AppendLine("|---|-------------|-------|-------|--------|-----------|------------|-------------|");
+            sb.AppendLine("| # | Temperature | Top-K | Top-P | Repeat | Mean Score | Variance | Δ Baseline | Avg Latency |");
+            sb.AppendLine("|---|-------------|-------|-------|--------|------------|----------|------------|-------------|");
 
             var rank = 1;
-            foreach (var entry in entries.OrderByDescending(e => e.AverageScore))
+            foreach (var entry in entries.OrderByDescending(e => e.MeanScore))
             {
-                var delta = entry.AverageScore - baselineAvg;
+                var delta = entry.MeanScore - baselineAvg;
                 var marker = entry == bestEntry ? " ⭐" : "";
                 sb.AppendLine(
                     $"| {rank++}{marker} | {entry.Profile.Temperature} | {entry.Profile.TopK} | " +
                     $"{entry.Profile.TopP} | {entry.Profile.RepeatPenalty} | " +
-                    $"{entry.AverageScore:F1} | {delta:+0.0;-0.0} | {entry.AverageLatencyMs:F0}ms |");
+                    $"{entry.MeanScore:F1} | {entry.ScoreVariance:F2} | {delta:+0.0;-0.0} | {entry.AverageLatencyMs:F0}ms |");
             }
             sb.AppendLine();
 
@@ -119,10 +119,10 @@ public static class SweepReportGenerator
         {
             if (!entries.Any()) continue;
 
-            var best = entries.OrderByDescending(e => e.AverageScore).First();
-            var delta = best.AverageScore - baselineAvg;
-            var pct = baselineAvg > 0 ? best.AverageScore / baselineAvg * 100 : 0;
-            sb.AppendLine($"- **{targetModel}:** Use `{best.Profile.ToSummary()}` → {best.AverageScore:F1} ({pct:F0}% of baseline, {delta:+0.0;-0.0} delta)");
+            var best = entries.OrderByDescending(e => e.MeanScore).First();
+            var delta = best.MeanScore - baselineAvg;
+            var pct = baselineAvg > 0 ? best.MeanScore / baselineAvg * 100 : 0;
+            sb.AppendLine($"- **{targetModel}:** Use `{best.Profile.ToSummary()}` → {best.MeanScore:F1} ({pct:F0}% of baseline, {delta:+0.0;-0.0} delta)");
         }
 
         return sb.ToString();
@@ -143,7 +143,7 @@ public static class SweepReportGenerator
         targets = result.TargetResults.Select(kvp => new
         {
             model = kvp.Key,
-            bestConfig = kvp.Value.OrderByDescending(e => e.AverageScore).Select(e => new
+            bestConfig = kvp.Value.OrderByDescending(e => e.MeanScore).Select(e => new
             {
                 parameters = new
                 {
@@ -153,11 +153,14 @@ public static class SweepReportGenerator
                     e.Profile.TopP,
                     e.Profile.RepeatPenalty
                 },
-                averageScore = e.AverageScore,
+                meanScore = e.MeanScore,
+                scoreVariance = e.ScoreVariance,
+                minRunMean = e.MinRunMean,
+                runCount = e.AllRunResults.Count,
                 averageLatencyMs = e.AverageLatencyMs,
                 agents = e.Results.Select(r => new { r.AgentName, r.OverallScore })
             }).FirstOrDefault(),
-            allConfigs = kvp.Value.OrderByDescending(e => e.AverageScore).Select(e => new
+            allConfigs = kvp.Value.OrderByDescending(e => e.MeanScore).Select(e => new
             {
                 parameters = new
                 {
@@ -166,7 +169,9 @@ public static class SweepReportGenerator
                     e.Profile.TopP,
                     e.Profile.RepeatPenalty
                 },
-                averageScore = e.AverageScore,
+                meanScore = e.MeanScore,
+                scoreVariance = e.ScoreVariance,
+                runCount = e.AllRunResults.Count,
                 averageLatencyMs = e.AverageLatencyMs
             })
         })

--- a/lucia.EvalHarness/Reports/SweepReportGenerator.cs
+++ b/lucia.EvalHarness/Reports/SweepReportGenerator.cs
@@ -85,7 +85,7 @@ public static class SweepReportGenerator
             sb.AppendLine("|---|-------------|-------|-------|--------|------------|---|---------------------|-------------|");
 
             var rank = 1;
-            foreach (var entry in entries.OrderByDescending(e => e.MeanScore))
+            foreach (var entry in entries.OrderByDescending(e => e.MeanScore).ThenBy(e => e.ScoreVariance))
             {
                 var delta = entry.MeanScore - baselineMean;
                 var marker = entry == bestEntry ? " *" : "";
@@ -171,7 +171,7 @@ public static class SweepReportGenerator
                     averageLatencyMs = e.AverageLatencyMs,
                     agents = e.Results.Select(r => new { r.AgentName, r.OverallScore })
                 }).FirstOrDefault(),
-            allConfigs = kvp.Value.OrderByDescending(e => e.MeanScore).Select(e => new
+            allConfigs = kvp.Value.OrderByDescending(e => e.MeanScore).ThenBy(e => e.ScoreVariance).Select(e => new
             {
                 parameters = new
                 {

--- a/lucia.EvalHarness/Reports/SweepReportGenerator.cs
+++ b/lucia.EvalHarness/Reports/SweepReportGenerator.cs
@@ -50,13 +50,13 @@ public static class SweepReportGenerator
         sb.AppendLine($"| Timestamp | {result.StartedAt:yyyy-MM-dd HH:mm:ss} UTC |");
         sb.AppendLine();
 
-        // Baseline scores
-        var baselineAvg = result.BaselineResults.Average(r => r.OverallScore);
+        // Baseline scores — BaselineMeanScore is the mean across all N baseline runs
+        var baselineMean = result.BaselineMeanScore;
         var baselineModel = result.BaselineResults.FirstOrDefault()?.ModelName ?? "unknown";
-        sb.AppendLine($"## Baseline: {baselineModel} (score: {baselineAvg:F1})");
+        sb.AppendLine($"## Baseline: {baselineModel} (mean score: {baselineMean:F1})");
         sb.AppendLine();
-        sb.AppendLine("| Agent | Score |");
-        sb.AppendLine("|-------|-------|");
+        sb.AppendLine("| Agent | Score (run 1) |");
+        sb.AppendLine("|-------|---------------|");
         foreach (var br in result.BaselineResults)
         {
             sb.AppendLine($"| {br.AgentName} | {br.OverallScore:F1} |");
@@ -68,38 +68,39 @@ public static class SweepReportGenerator
         {
             if (!entries.Any()) continue;
 
-            sb.AppendLine($"## {targetModel} — Parameter Sweep Results");
+            sb.AppendLine($"## {targetModel} -- Parameter Sweep Results");
             sb.AppendLine();
 
-            // Summary: best configuration
-            var bestEntry = entries.OrderByDescending(e => e.MeanScore).First();
+            // Use SweepRunAggregator.SelectWinner so the reported config exactly matches
+            // what the runner selected (mean primary, variance tie-breaker).
+            var bestEntry = SweepRunAggregator.SelectWinner(entries);
             var worstEntry = entries.OrderBy(e => e.MeanScore).First();
-            sb.AppendLine($"- **Best config:** {bestEntry.Profile.ToSummary()} → **{bestEntry.MeanScore:F1}** (Δ from baseline: {bestEntry.MeanScore - baselineAvg:+0.0;-0.0}, var: {bestEntry.ScoreVariance:F2})");
-            sb.AppendLine($"- **Worst config:** {worstEntry.Profile.ToSummary()} → **{worstEntry.MeanScore:F1}**");
-            sb.AppendLine($"- **Score range:** {worstEntry.MeanScore:F1} – {bestEntry.MeanScore:F1}");
+            sb.AppendLine($"- **Best config:** {bestEntry.Profile.ToSummary()} -> **{bestEntry.MeanScore:F1}** (delta from baseline mean: {bestEntry.MeanScore - baselineMean:+0.0;-0.0}, σ={bestEntry.ScoreStdDev:F2})");
+            sb.AppendLine($"- **Worst config:** {worstEntry.Profile.ToSummary()} -> **{worstEntry.MeanScore:F1}**");
+            sb.AppendLine($"- **Score range:** {worstEntry.MeanScore:F1} - {bestEntry.MeanScore:F1}");
             sb.AppendLine();
 
             // Full results table
-            sb.AppendLine("| # | Temperature | Top-K | Top-P | Repeat | Mean Score | Variance | Δ Baseline | Avg Latency |");
-            sb.AppendLine("|---|-------------|-------|-------|--------|------------|----------|------------|-------------|");
+            sb.AppendLine("| # | Temperature | Top-K | Top-P | Repeat | Mean Score | σ | Delta from Baseline | Avg Latency |");
+            sb.AppendLine("|---|-------------|-------|-------|--------|------------|---|---------------------|-------------|");
 
             var rank = 1;
             foreach (var entry in entries.OrderByDescending(e => e.MeanScore))
             {
-                var delta = entry.MeanScore - baselineAvg;
-                var marker = entry == bestEntry ? " ⭐" : "";
+                var delta = entry.MeanScore - baselineMean;
+                var marker = entry == bestEntry ? " *" : "";
                 sb.AppendLine(
                     $"| {rank++}{marker} | {entry.Profile.Temperature} | {entry.Profile.TopK} | " +
                     $"{entry.Profile.TopP} | {entry.Profile.RepeatPenalty} | " +
-                    $"{entry.MeanScore:F1} | {entry.ScoreVariance:F2} | {delta:+0.0;-0.0} | {entry.AverageLatencyMs:F0}ms |");
+                    $"{entry.MeanScore:F1} | {entry.ScoreStdDev:F2} | {delta:+0.0;-0.0} | {entry.AverageLatencyMs:F0}ms |");
             }
             sb.AppendLine();
 
             // Per-agent breakdown for best config
             sb.AppendLine($"### Best Config Breakdown ({bestEntry.Profile.ToSummary()})");
             sb.AppendLine();
-            sb.AppendLine("| Agent | Score | Baseline | Delta |");
-            sb.AppendLine("|-------|-------|----------|-------|");
+            sb.AppendLine("| Agent | Score (run 1) | Baseline | Delta |");
+            sb.AppendLine("|-------|---------------|----------|-------|");
 
             foreach (var agentResult in bestEntry.Results)
             {
@@ -119,10 +120,11 @@ public static class SweepReportGenerator
         {
             if (!entries.Any()) continue;
 
-            var best = entries.OrderByDescending(e => e.MeanScore).First();
-            var delta = best.MeanScore - baselineAvg;
-            var pct = baselineAvg > 0 ? best.MeanScore / baselineAvg * 100 : 0;
-            sb.AppendLine($"- **{targetModel}:** Use `{best.Profile.ToSummary()}` → {best.MeanScore:F1} ({pct:F0}% of baseline, {delta:+0.0;-0.0} delta)");
+            // Use SelectWinner for consistent winner selection with the runner
+            var best = SweepRunAggregator.SelectWinner(entries);
+            var delta = best.MeanScore - baselineMean;
+            var pct = baselineMean > 0 ? best.MeanScore / baselineMean * 100 : 0;
+            sb.AppendLine($"- **{targetModel}:** Use `{best.Profile.ToSummary()}` -> {best.MeanScore:F1} ({pct:F0}% of baseline mean, {delta:+0.0;-0.0} delta)");
         }
 
         return sb.ToString();
@@ -137,29 +139,38 @@ public static class SweepReportGenerator
         baseline = new
         {
             model = result.BaselineResults.FirstOrDefault()?.ModelName,
-            averageScore = result.BaselineResults.Average(r => r.OverallScore),
+            // Emit both for backward compat and new consumers
+            averageScore = result.BaselineMeanScore,
+            meanScore = result.BaselineMeanScore,
             agents = result.BaselineResults.Select(r => new { r.AgentName, r.OverallScore })
         },
         targets = result.TargetResults.Select(kvp => new
         {
             model = kvp.Key,
-            bestConfig = kvp.Value.OrderByDescending(e => e.MeanScore).Select(e => new
-            {
-                parameters = new
+            // Use SelectWinner so the JSON best-config matches what the runner chose
+            bestConfig = kvp.Value
+                .OrderByDescending(e => e.MeanScore)
+                .ThenBy(e => e.ScoreVariance)
+                .Select(e => new
                 {
-                    e.Profile.Name,
-                    e.Profile.Temperature,
-                    e.Profile.TopK,
-                    e.Profile.TopP,
-                    e.Profile.RepeatPenalty
-                },
-                meanScore = e.MeanScore,
-                scoreVariance = e.ScoreVariance,
-                minRunMean = e.MinRunMean,
-                runCount = e.AllRunResults.Count,
-                averageLatencyMs = e.AverageLatencyMs,
-                agents = e.Results.Select(r => new { r.AgentName, r.OverallScore })
-            }).FirstOrDefault(),
+                    parameters = new
+                    {
+                        e.Profile.Name,
+                        e.Profile.Temperature,
+                        e.Profile.TopK,
+                        e.Profile.TopP,
+                        e.Profile.RepeatPenalty
+                    },
+                    // Emit both averageScore (backward compat) and meanScore (new)
+                    averageScore = e.AverageScore,
+                    meanScore = e.MeanScore,
+                    scoreVariance = e.ScoreVariance,
+                    scoreStdDev = e.ScoreStdDev,
+                    minRunMean = e.MinRunMean,
+                    runCount = e.AllRunResults.Count,
+                    averageLatencyMs = e.AverageLatencyMs,
+                    agents = e.Results.Select(r => new { r.AgentName, r.OverallScore })
+                }).FirstOrDefault(),
             allConfigs = kvp.Value.OrderByDescending(e => e.MeanScore).Select(e => new
             {
                 parameters = new
@@ -169,8 +180,11 @@ public static class SweepReportGenerator
                     e.Profile.TopP,
                     e.Profile.RepeatPenalty
                 },
+                // Emit both averageScore (backward compat) and meanScore (new)
+                averageScore = e.AverageScore,
                 meanScore = e.MeanScore,
                 scoreVariance = e.ScoreVariance,
+                scoreStdDev = e.ScoreStdDev,
                 runCount = e.AllRunResults.Count,
                 averageLatencyMs = e.AverageLatencyMs
             })

--- a/lucia.EvalHarness/Tui/ParameterSweepSelector.cs
+++ b/lucia.EvalHarness/Tui/ParameterSweepSelector.cs
@@ -76,9 +76,17 @@ public static class ParameterSweepSelector
             new TextPrompt<int>("[cornflowerblue]Max parameter combinations per model[/]:")
                 .DefaultValue(config.MaxCombinations));
 
+        config.RunsPerCombination = AnsiConsole.Prompt(
+            new TextPrompt<int>("[cornflowerblue]Runs per combination[/] (1 = single-run, 3 = default noise-resistant):")
+                .DefaultValue(config.RunsPerCombination)
+                .Validate(n => n >= 1
+                    ? ValidationResult.Success()
+                    : ValidationResult.Error("Must be at least 1")));
+
         var totalCombinations = config.GenerateCombinations().Count;
-        var totalRuns = totalCombinations * targetModels.Count * agents.Count;
-        AnsiConsole.MarkupLine($"[dim]  {totalCombinations} parameter combinations × {targetModels.Count} models × {agents.Count} agents = {totalRuns} total evaluation runs[/]");
+        var runsEach = config.RunsPerCombination;
+        var totalRuns = totalCombinations * targetModels.Count * agents.Count * runsEach;
+        AnsiConsole.MarkupLine($"[dim]  {totalCombinations} combos × {targetModels.Count} models × {agents.Count} agents × {runsEach} runs each = {totalRuns} total eval calls[/]");
         AnsiConsole.WriteLine();
 
         if (!AnsiConsole.Confirm("[bold]Proceed with sweep?[/]"))


### PR DESCRIPTION
## Summary

Fixes the statistical validity of parameter sweep winner selection.

**Root cause:** ParameterSweepRunner evaluated each combination exactly once and picked the winner with the highest single-run score. Non-deterministic LLM outputs meant the 'winner' was often just lucky noise.

**Fix:** Each combination is now evaluated RunsPerCombination times (default **3**). The winner is selected by the **mean score across all N runs**, with **score variance as a tie-breaker** (lower variance wins, i.e., a stable mid-scorer beats an unpredictable high-scorer on a tie).

## Changes

- ParameterSweepConfig.RunsPerCombination — new property, default **3**. Set to **1** to restore the old single-run behaviour.
- **SweepRunAggregator** — new pure static class: ComputeMean, ComputeVariance, ComputeMinRunMean, SelectWinner, DeriveRunSeed.
- **SweepEntry** — new fields: AllRunResults, MeanScore, ScoreVariance, MinRunMean; AverageScore is an alias for MeanScore (backward compatible).
- **ParameterSweepRunner.RunAsync** — inner loop now runs N times per combo; seeds are offset per run (aseSeed + runIndex) when a base seed is configured.
- **SweepReportGenerator** — variance column added to the results table; JSON report includes unCount, scoreVariance, minRunMean.
- **lucia.EvalHarness.Tests** — new project with **18 fast provider-free unit tests** covering aggregation math, winner selection, seed derivation, and SweepEntry computed properties.

## Default N and aggregation strategy

| Property | Value |
|---|---|
| Default RunsPerCombination | **3** |
| Winner criterion | Highest mean score across all N runs |
| Tie-breaker | Lower score variance (more stable config wins) |
| Seed behaviour | aseSeed + runIndex so each run is reproducible yet distinct |

Closes #134