### PR TITLE
fix(tests): make live HA tests explicitly opt-in and add master to CI triggers

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -3,10 +3,10 @@ name: Squad CI
 
 on:
   pull_request:
-    branches: [dev, preview, main, insider]
+    branches: [master, dev, preview, main, insider]
     types: [opened, synchronize, reopened]
   push:
-    branches: [dev, insider]
+    branches: [master, dev, insider]
 
 permissions:
   contents: read

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet build lucia-dotnet.slnx --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test lucia.Tests --no-build --configuration Release --filter "Category!=Eval&Category!=Integration" --logger "console;verbosity=normal"
+        run: dotnet test lucia.Tests --no-build --configuration Release --filter "Category!=Eval&Category!=Integration&Category!=LiveEval" --logger "console;verbosity=normal"
 
       - name: Test EvalHarness (provider-free)
         run: dotnet test lucia.EvalHarness.Tests --no-build --configuration Release --logger "console;verbosity=normal"

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -66,3 +66,20 @@ WyomingSession integration test pattern for feature flag validation:
 - Combine both into allAgents list for assertion
 
 - Participated in 2026-05-29 health review
+
+### Issue #148: Provider-free eval opt-in (2026-07-12)
+
+**Problem:** Behavior-critical routing/aggregation paths were only covered by `Category=Eval` tests that skip under CI placeholder credentials, so regressions in `RouterExecutor` fallback/clarification/normalization and `ResultAggregatorExecutor` composition were invisible to ordinary CI.
+
+**What changed:**
+- `RouterExecutorFallbackTests.cs` (new, 7 tests) — deterministic coverage of: no-agents fallback, unknown-agent fallback, confidence-below-threshold clarification, max-retry exhaustion, NormalizeAdditionalAgents filtering/dedup, OriginalUserText propagation.
+- `ResultAggregatorExecutorTests.cs` (new, 13 test cases) — deterministic coverage of: single success, empty-content template, single failure format, multi-failure format, mixed success+failure, empty-responses fallback, NeedsInput flag, multi-success join, priority ordering, agent name title-casing.
+- `HomeAssistantApiTests.cs` — added `[Trait("Category","LiveEval")]` at class level to make the HA-live opt-in explicit (previously silently skipped).
+- `squad-ci.yml` — added `&Category!=LiveEval` to the CI filter so HA live tests are excluded by policy, not just luck.
+
+**Key decisions:**
+- Reused `StubChatClient`, `AgentsTelemetrySource`, `FakeItEasy` fakes — no new infrastructure.
+- `DurableTaskPersistenceTests` left as-is (Docker/Redis available in CI, not credential-gated, tests pass).
+- All 20 new tests pass in < 1 second total; CI test count 1124 → 1130, skipped 21 → 7.
+- Slopwatch: not installed as local tool; manual checks confirmed no disabled tests, warning suppressions, empty catch blocks, or arbitrary delays.
+- One class per file maintained.

--- a/lucia.Tests/HomeAssistantApiTests.cs
+++ b/lucia.Tests/HomeAssistantApiTests.cs
@@ -2,6 +2,10 @@ using lucia.HomeAssistant.Services;
 
 namespace lucia.Tests;
 
+// Tests in this class require a live Home Assistant instance configured via
+// HA_ENDPOINT and HA_TOKEN. They are excluded from CI via [Trait("Category","LiveEval")]
+// and only run when explicitly requested with --filter "Category=LiveEval".
+[Trait("Category", "LiveEval")]
 public class HomeAssistantApiTests
 {
     private readonly HomeAssistantClient? _client;

--- a/lucia.Tests/HomeAssistantErrorHandlingTests.cs
+++ b/lucia.Tests/HomeAssistantErrorHandlingTests.cs
@@ -66,7 +66,7 @@ public class HomeAssistantErrorHandlingTests
     private void SkipIfNotConfigured() =>
         Skip.If(!HomeAssistantTestConfig.IsConfigured, "HA_ENDPOINT and HA_TOKEN not configured.");
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task GetStatesAsync_WithInvalidToken_ShouldThrowUnauthorized()
     {
         SkipIfNotConfigured();
@@ -75,7 +75,7 @@ public class HomeAssistantErrorHandlingTests
         Assert.Contains("401", exception.Message);
     }
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task GetStateAsync_WithInvalidToken_ShouldThrowUnauthorized()
     {
         SkipIfNotConfigured();
@@ -84,7 +84,7 @@ public class HomeAssistantErrorHandlingTests
         Assert.Contains("401", exception.Message);
     }
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task GetConfigAsync_WithInvalidToken_ShouldThrowUnauthorized()
     {
         SkipIfNotConfigured();
@@ -93,7 +93,7 @@ public class HomeAssistantErrorHandlingTests
         Assert.Contains("401", exception.Message);
     }
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task CallServiceAsync_WithInvalidToken_ShouldThrowUnauthorized()
     {
         SkipIfNotConfigured();
@@ -126,7 +126,7 @@ public class HomeAssistantErrorHandlingTests
             $"Expected HttpRequestException or TaskCanceledException, but got {exception.GetType().Name}");
     }
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task CallServiceAsync_WithInvalidDomain_ShouldThrowHttpRequestException()
     {
         SkipIfNotConfigured();
@@ -137,7 +137,7 @@ public class HomeAssistantErrorHandlingTests
         Assert.Contains("400", exception.Message);
     }
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task GetStateAsync_WithNonExistentEntity_ShouldReturnNull()
     {
         SkipIfNotConfigured();
@@ -147,7 +147,7 @@ public class HomeAssistantErrorHandlingTests
         Assert.Null(result);
     }
 
-    [SkippableFact]
+    [SkippableFact, Trait("Category", "LiveEval")]
     public async Task FireEventAsync_WithInvalidEventType_ShouldStillSucceed()
     {
         SkipIfNotConfigured();

--- a/lucia.Tests/Orchestration/ResultAggregatorExecutorTests.cs
+++ b/lucia.Tests/Orchestration/ResultAggregatorExecutorTests.cs
@@ -1,0 +1,247 @@
+using FakeItEasy;
+
+using lucia.Agents.Orchestration;
+using lucia.Agents.Orchestration.Models;
+
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace lucia.Tests.Orchestration;
+
+/// <summary>
+/// Provider-free unit tests for <see cref="ResultAggregatorExecutor"/> response composition.
+/// Covers success, failure, mixed, empty, priority-ordering, NeedsInput propagation, and
+/// agent name formatting — all without a live LLM provider.
+/// </summary>
+public sealed class ResultAggregatorExecutorTests
+{
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    private static IWorkflowContext CreateContext()
+    {
+        var context = A.Fake<IWorkflowContext>();
+        A.CallTo(() => context.AddEventAsync(A<WorkflowEvent>._, A<CancellationToken>._))
+            .Returns(new ValueTask());
+        return context;
+    }
+
+    private static ResultAggregatorExecutor CreateAggregator(
+        ResultAggregatorOptions? options = null)
+    {
+        return new ResultAggregatorExecutor(
+            NullLogger<ResultAggregatorExecutor>.Instance,
+            Options.Create(options ?? new ResultAggregatorOptions()));
+    }
+
+    private static OrchestratorAgentResponse Success(string agentId, string content = "Done.") =>
+        new()
+        {
+            AgentId = agentId,
+            Content = content,
+            Success = true,
+            ExecutionTimeMs = 1
+        };
+
+    private static OrchestratorAgentResponse Failure(string agentId, string error = "Service unavailable") =>
+        new()
+        {
+            AgentId = agentId,
+            Content = string.Empty,
+            Success = false,
+            ErrorMessage = error,
+            ExecutionTimeMs = 1
+        };
+
+    // ─── Single success ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SingleSuccess_ReturnsAgentContent()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Success("light-agent", "The kitchen lights are now on.")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Equal("The kitchen lights are now on.", result.Text);
+        Assert.False(result.NeedsInput);
+    }
+
+    // ─── Success with empty content → default template ────────────────
+
+    [Fact]
+    public async Task HandleAsync_SuccessWithEmptyContent_UsesDefaultSuccessTemplate()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Success("light-agent", string.Empty)
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Contains("Light Agent", result.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("completed", result.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Single failure ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SingleFailure_ReturnsFailureMessage()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Failure("music-agent", "no speaker available")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Contains("couldn't complete", result.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Music Agent", result.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no speaker available", result.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Multiple failures ────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_MultipleFailures_ReturnsMultiFailureFormat()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Failure("music-agent", "no speaker"),
+            Failure("light-agent", "device offline")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Contains("issues with", result.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Mixed success + failure ──────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_MixedSuccessAndFailure_IncludesBothParts()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Success("light-agent", "Lights are on."),
+            Failure("music-agent", "no speaker available")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Contains("Lights are on", result.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("couldn't complete", result.Text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Music Agent", result.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Empty response list ──────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_EmptyResponses_ReturnsFallbackMessage()
+    {
+        var options = new ResultAggregatorOptions
+        {
+            DefaultFallbackMessage = "Still working on that."
+        };
+        var aggregator = CreateAggregator(options);
+
+        var result = await aggregator.HandleAsync(
+            new List<OrchestratorAgentResponse>(),
+            CreateContext(),
+            CancellationToken.None);
+
+        Assert.Equal("Still working on that.", result.Text);
+    }
+
+    // ─── NeedsInput propagation ───────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_AgentNeedsInput_SetsNeedsInputOnResult()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            new()
+            {
+                AgentId = "light-agent",
+                Content = "Which lights should I turn on?",
+                Success = true,
+                NeedsInput = true,
+                ExecutionTimeMs = 1
+            }
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.True(result.NeedsInput);
+    }
+
+    // ─── Multiple successes joined ────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_MultipleSuccesses_JoinsAllContentInResult()
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Success("light-agent", "Lights dimmed."),
+            Success("music-agent", "Playing jazz.")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Contains("Lights dimmed", result.Text);
+        Assert.Contains("Playing jazz", result.Text);
+    }
+
+    // ─── Priority ordering ────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_AgentPriority_PlacesLightAgentBeforeMusicAgent()
+    {
+        // Default priority list: light-agent (index 0), music-agent (index 1)
+        var aggregator = CreateAggregator();
+
+        // Provide responses in reverse priority order to confirm ordering is applied
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Success("music-agent", "Playing jazz."),
+            Success("light-agent", "Lights dimmed.")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        var lightIdx = result.Text.IndexOf("Lights dimmed", StringComparison.OrdinalIgnoreCase);
+        var musicIdx = result.Text.IndexOf("Playing jazz", StringComparison.OrdinalIgnoreCase);
+        Assert.True(lightIdx < musicIdx,
+            "light-agent response should appear before music-agent response per default priority");
+    }
+
+    // ─── Agent name formatting ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("light-agent", "Light Agent")]
+    [InlineData("music-agent", "Music Agent")]
+    [InlineData("climate-agent", "Climate Agent")]
+    [InlineData("general-assistant", "General Assistant")]
+    public async Task HandleAsync_AgentNameFormatting_ProducesTitleCaseInFailureMessage(
+        string agentId, string expectedName)
+    {
+        var aggregator = CreateAggregator();
+        var responses = new List<OrchestratorAgentResponse>
+        {
+            Failure(agentId, "some error")
+        };
+
+        var result = await aggregator.HandleAsync(responses, CreateContext(), CancellationToken.None);
+
+        Assert.Contains(expectedName, result.Text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/lucia.Tests/Orchestration/RouterExecutorFallbackTests.cs
+++ b/lucia.Tests/Orchestration/RouterExecutorFallbackTests.cs
@@ -1,0 +1,244 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+using A2A;
+
+using FakeItEasy;
+
+using lucia.Agents;
+using lucia.Agents.Orchestration;
+using lucia.Agents.Registry;
+using lucia.Tests.TestDoubles;
+
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace lucia.Tests.Orchestration;
+
+/// <summary>
+/// Provider-free unit tests for <see cref="RouterExecutor"/> routing and fallback logic.
+/// Uses <see cref="StubChatClient"/> with pre-serialized JSON so CI exercises the real
+/// routing/fallback/clarification/normalization code paths without a live LLM.
+/// </summary>
+public sealed class RouterExecutorFallbackTests
+{
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    private static RouterExecutor CreateRouter(
+        IChatClient chatClient,
+        IAgentRegistry registry,
+        RouterExecutorOptions? options = null)
+    {
+        return new RouterExecutor(
+            chatClient,
+            registry,
+            NullLogger<RouterExecutor>.Instance,
+            new AgentsTelemetrySource(),
+            Options.Create(options ?? new RouterExecutorOptions()));
+    }
+
+    private static AgentCard MakeAgent(string name, string description = "Test agent") => new()
+    {
+        Name = name,
+        Description = description,
+        Version = "1.0.0",
+        Capabilities = new AgentCapabilities(),
+        DefaultInputModes = ["text"],
+        DefaultOutputModes = ["text"],
+        Skills = []
+    };
+
+    private static IAgentRegistry RegistryWith(params AgentCard[] agents)
+    {
+        var registry = A.Fake<IAgentRegistry>();
+        A.CallTo(() => registry.GetEnumerableAgentsAsync(A<CancellationToken>._))
+            .Returns(StreamAgentsAsync(agents));
+        return registry;
+    }
+
+    private static async IAsyncEnumerable<AgentCard> StreamAgentsAsync(
+        IEnumerable<AgentCard> agents,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var agent in agents)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return agent;
+            await Task.Yield();
+        }
+    }
+
+    private static string RoutingJson(
+        string agentId,
+        double confidence = 0.95,
+        string? reasoning = null,
+        string[]? additionalAgents = null)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            agentId,
+            reasoning = reasoning ?? $"Route to {agentId}.",
+            confidence,
+            additionalAgents
+        }, RouterExecutor.JsonSerializerOptions);
+    }
+
+    // ─── No agents registered ─────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NoAgentsRegistered_ReturnsFallbackWithoutCallingLlm()
+    {
+        var chatClient = A.Fake<IChatClient>();
+        var router = CreateRouter(chatClient, RegistryWith());
+
+        var result = await router.HandleAsync(
+            new ChatMessage(ChatRole.User, "turn on the lights"),
+            A.Fake<IWorkflowContext>());
+
+        Assert.Equal(RouterExecutorOptions.DefaultFallbackAgentId, result.AgentId);
+        Assert.Equal(0, result.Confidence);
+        A.CallTo(() => chatClient.GetResponseAsync(
+            A<IEnumerable<ChatMessage>>._, A<ChatOptions>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    // ─── LLM returns unknown agent → fallback ─────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_LlmReturnsUnknownAgent_ReturnsFallback()
+    {
+        var registry = RegistryWith(MakeAgent("light-agent"));
+        var chatClient = new StubChatClient([
+            _ => new ChatResponse([new ChatMessage(ChatRole.Assistant,
+                RoutingJson("nonexistent-agent"))])
+        ]);
+
+        var router = CreateRouter(chatClient, registry);
+        var result = await router.HandleAsync(
+            new ChatMessage(ChatRole.User, "do something"),
+            A.Fake<IWorkflowContext>());
+
+        Assert.Equal(RouterExecutorOptions.DefaultFallbackAgentId, result.AgentId);
+        Assert.Equal(0, result.Confidence);
+    }
+
+    // ─── Confidence below threshold → clarification ──────────────────
+
+    [Fact]
+    public async Task HandleAsync_ConfidenceBelowThreshold_ReturnsClarificationAgent()
+    {
+        var registry = RegistryWith(
+            MakeAgent("light-agent"),
+            MakeAgent("climate-agent"));
+
+        // Confidence 0.5 < default threshold 0.7 → clarification
+        var chatClient = new StubChatClient([
+            _ => new ChatResponse([new ChatMessage(ChatRole.Assistant,
+                RoutingJson("light-agent", confidence: 0.5,
+                    reasoning: "Unclear device. Which one did you mean?"))])
+        ]);
+
+        var router = CreateRouter(chatClient, registry);
+        var result = await router.HandleAsync(
+            new ChatMessage(ChatRole.User, "adjust the thing"),
+            A.Fake<IWorkflowContext>());
+
+        Assert.Equal(RouterExecutorOptions.DefaultClarificationAgentId, result.AgentId);
+    }
+
+    // ─── All JSON parse attempts exhaust → fallback ───────────────────
+
+    [Fact]
+    public async Task HandleAsync_AllAttemptsMalformedJson_ReturnsFallbackAfterRetries()
+    {
+        var registry = RegistryWith(MakeAgent("light-agent"));
+        const string malformedJson = "not json at all";
+        var chatClient = new StubChatClient([
+            _ => new ChatResponse([new ChatMessage(ChatRole.Assistant, malformedJson)]),
+            _ => new ChatResponse([new ChatMessage(ChatRole.Assistant, malformedJson)])
+        ]);
+
+        var options = new RouterExecutorOptions { MaxAttempts = 2 };
+        var router = CreateRouter(chatClient, registry, options);
+        var result = await router.HandleAsync(
+            new ChatMessage(ChatRole.User, "turn on lights"),
+            A.Fake<IWorkflowContext>());
+
+        Assert.Equal(RouterExecutorOptions.DefaultFallbackAgentId, result.AgentId);
+        Assert.Equal(0, result.Confidence);
+        Assert.Equal(2, chatClient.InvocationCount);
+    }
+
+    // ─── NormalizeAdditionalAgents: unknown names filtered ───────────
+
+    [Fact]
+    public async Task HandleAsync_AdditionalAgentsContainUnknownNames_FiltersToKnownOnly()
+    {
+        var registry = RegistryWith(
+            MakeAgent("light-agent"),
+            MakeAgent("music-agent"));
+
+        var payload = RoutingJson("light-agent", additionalAgents: ["music-agent", "nonexistent-agent", "fantasy-agent"]);
+        var chatClient = new StubChatClient([
+            _ => new ChatResponse([new ChatMessage(ChatRole.Assistant, payload)])
+        ]);
+
+        var router = CreateRouter(chatClient, registry);
+        var result = await router.HandleAsync(
+            new ChatMessage(ChatRole.User, "dim lights and play music"),
+            A.Fake<IWorkflowContext>());
+
+        Assert.Equal("light-agent", result.AgentId);
+        Assert.NotNull(result.AdditionalAgents);
+        Assert.Single(result.AdditionalAgents);
+        Assert.Equal("music-agent", result.AdditionalAgents[0]);
+    }
+
+    // ─── NormalizeAdditionalAgents: primary agent removed from list ──
+
+    [Fact]
+    public async Task HandleAsync_AdditionalAgentsContainPrimaryAgent_RemovesPrimary()
+    {
+        var registry = RegistryWith(
+            MakeAgent("light-agent"),
+            MakeAgent("music-agent"));
+
+        // LLM mistakenly includes the primary in additionalAgents
+        var payload = RoutingJson("light-agent", additionalAgents: ["light-agent", "music-agent"]);
+        var chatClient = new StubChatClient([
+            _ => new ChatResponse([new ChatMessage(ChatRole.Assistant, payload)])
+        ]);
+
+        var router = CreateRouter(chatClient, registry);
+        var result = await router.HandleAsync(
+            new ChatMessage(ChatRole.User, "control lights and music"),
+            A.Fake<IWorkflowContext>());
+
+        Assert.Equal("light-agent", result.AgentId);
+        Assert.NotNull(result.AdditionalAgents);
+        Assert.Single(result.AdditionalAgents);
+        Assert.DoesNotContain("light-agent", result.AdditionalAgents, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("music-agent", result.AdditionalAgents[0]);
+    }
+
+    // ─── OriginalUserText preserved on no-agents fallback ────────────
+
+    [Fact]
+    public async Task HandleAsync_OriginalUserTextInMetadata_PreservedOnFallback()
+    {
+        var router = CreateRouter(A.Fake<IChatClient>(), RegistryWith());
+        var message = new ChatMessage(ChatRole.User, "Licht an")
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["lucia.originalUserText"] = "Licht an"
+            }
+        };
+
+        var result = await router.HandleAsync(message, A.Fake<IWorkflowContext>());
+
+        Assert.Equal("Licht an", result.OriginalUserText);
+    }
+}


### PR DESCRIPTION
## Summary

Make live Home Assistant eval tests explicitly opt-in and ensure normal CI
delivers deterministic provider-free coverage on the default branch.

### Changes

**`lucia.Tests/HomeAssistantErrorHandlingTests.cs`**
Seven `[SkippableFact]` tests that require a live HA endpoint (invalid-token
401 probes and service/entity boundary checks) now carry
`[Trait("Category", "LiveEval")]` at the narrowest correct scope (per-test,
not class-level), matching the opt-in pattern already on `HomeAssistantApiTests`.
The two `[Fact]` tests that exercise `HttpRequestException`/`TaskCanceledException`
against an unresolvable URL are provider-free and unchanged.

**`.github/workflows/squad-ci.yml`**
Added `master` to both `on:pull_request.branches` and `on:push.branches`.
Without this, PRs and pushes targeting the default branch never triggered the
workflow, defeating the purpose of the provider-free coverage added in d850143.
The existing CI filter (`Category!=Eval&Category!=Integration&Category!=LiveEval`)
is unchanged and correct.

### Validation

| Check | Result |
|---|---|
| Build (Release, full solution) | 0 errors, 0 warnings |
| CI filter run (`lucia.Tests` w/ `Category!=Eval&Category!=Integration&Category!=LiveEval`) | **1123 passed, 0 failed** |
| Provider-free orchestration tests (`RouterExecutorFallbackTests` + `ResultAggregatorExecutorTests`) | **20 passed** |
| Provider-free HA error tests (invalid-URL `[Fact]` pair) | **2 passed** |
| Slopwatch (manual SW001–SW006 scan on changed files) | Clean |
| Vasquez pre-push gate | Approved at `1ceb4fe3` |

No Skip attributes added. No new dependencies. One class per file maintained.

Closes #148
