### PR TITLE
fix(eval): deterministic seed defaults with explicit null opt-out across baseline and targets

### DIFF
--- a/lucia.EvalHarness.Tests/ModelParameterProfileDefaultSeedTests.cs
+++ b/lucia.EvalHarness.Tests/ModelParameterProfileDefaultSeedTests.cs
@@ -1,0 +1,195 @@
+using lucia.EvalHarness.Configuration;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Verifies that all named profiles and generated sweep combinations carry a
+/// deterministic default seed. Eliminates run-to-run score drift caused by
+/// <c>Seed = null</c> non-determinism (issue #132).
+///
+/// Relationship with #130: #130 forwards seed/temperature knobs via typed
+/// <c>ChatOptions</c> to providers. This suite only validates the configuration
+/// layer. Do not merge forwarding logic here.
+/// </summary>
+public sealed class ModelParameterProfileDefaultSeedTests
+{
+    // ──────────────────────────────────────────────────────────────
+    // Named profiles must have a non-null, deterministic seed
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Default_Profile_HasNonNullSeed()
+    {
+        Assert.NotNull(ModelParameterProfile.Default.Seed);
+    }
+
+    [Fact]
+    public void Precise_Profile_HasNonNullSeed()
+    {
+        Assert.NotNull(ModelParameterProfile.Precise.Seed);
+    }
+
+    [Fact]
+    public void Creative_Profile_HasNonNullSeed()
+    {
+        Assert.NotNull(ModelParameterProfile.Creative.Seed);
+    }
+
+    [Fact]
+    public void All_BuiltInProfiles_HaveNonNullSeed()
+    {
+        foreach (var (name, profile) in ModelParameterProfile.BuiltInProfiles)
+        {
+            Assert.True(
+                profile.Seed.HasValue,
+                $"Built-in profile '{name}' must have a non-null Seed for reproducibility");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Default construction must carry a deterministic seed
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultConstruction_HasNonNullSeed()
+    {
+        var profile = new ModelParameterProfile { Name = "custom" };
+        Assert.NotNull(profile.Seed);
+    }
+
+    [Fact]
+    public void DefaultConstruction_SeedEqualsDefaultSeedConstant()
+    {
+        var profile = new ModelParameterProfile { Name = "custom" };
+        Assert.Equal(ModelParameterProfile.DefaultSeed, profile.Seed);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // All named profiles use the same shared constant, not magic numbers
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Default_Profile_SeedEqualsDefaultSeedConstant()
+    {
+        Assert.Equal(ModelParameterProfile.DefaultSeed, ModelParameterProfile.Default.Seed);
+    }
+
+    [Fact]
+    public void Precise_Profile_SeedEqualsDefaultSeedConstant()
+    {
+        Assert.Equal(ModelParameterProfile.DefaultSeed, ModelParameterProfile.Precise.Seed);
+    }
+
+    [Fact]
+    public void Creative_Profile_SeedEqualsDefaultSeedConstant()
+    {
+        Assert.Equal(ModelParameterProfile.DefaultSeed, ModelParameterProfile.Creative.Seed);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Caller-provided seed must win over the default
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Seed_CanBeExplicitlyOverriddenToNull()
+    {
+        var profile = new ModelParameterProfile { Name = "custom", Seed = null };
+        Assert.Null(profile.Seed);
+    }
+
+    [Fact]
+    public void Seed_CanBeExplicitlyOverriddenToArbitraryValue()
+    {
+        var profile = new ModelParameterProfile { Name = "custom", Seed = 99 };
+        Assert.Equal(99, profile.Seed);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // ParameterSweepConfig: BaseSeed defaults to the shared constant
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParameterSweepConfig_BaseSeed_DefaultsToNonNull()
+    {
+        var config = new ParameterSweepConfig();
+        Assert.NotNull(config.BaseSeed);
+    }
+
+    [Fact]
+    public void ParameterSweepConfig_BaseSeed_DefaultsToDefaultSeedConstant()
+    {
+        var config = new ParameterSweepConfig();
+        Assert.Equal(ModelParameterProfile.DefaultSeed, config.BaseSeed);
+    }
+
+    [Fact]
+    public void ParameterSweepConfig_BaseSeed_CanBeOverriddenToNull()
+    {
+        var config = new ParameterSweepConfig { BaseSeed = null };
+        Assert.Null(config.BaseSeed);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // GenerateCombinations: default config produces seeded profiles
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateCombinations_WithDefaultConfig_AllCombosHaveNonNullSeed()
+    {
+        var config = new ParameterSweepConfig
+        {
+            TemperatureValues = [0.5, 1.0],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        var combos = config.GenerateCombinations();
+
+        Assert.NotEmpty(combos);
+        Assert.All(combos, p => Assert.NotNull(p.Seed));
+    }
+
+    [Fact]
+    public void GenerateCombinations_WithDefaultConfig_MultipleCombosHaveDistinctSeeds()
+    {
+        // Each combo must receive a unique seed block, not the same value
+        var config = new ParameterSweepConfig
+        {
+            TemperatureValues = [0.3, 0.7],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        var combos = config.GenerateCombinations();
+        var seeds = combos.Select(p => p.Seed).ToList();
+
+        Assert.Equal(seeds.Count, seeds.Distinct().Count());
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Explicit opt-out: BaseSeed = null still produces null seeds
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateCombinations_WithExplicitBaseSeedNull_AllCombosHaveNullSeed()
+    {
+        var config = new ParameterSweepConfig
+        {
+            BaseSeed = null,
+            TemperatureValues = [0.5],
+            TopKValues = [40],
+            TopPValues = [0.9],
+            RepeatPenaltyValues = [1.1],
+            MaxCombinations = 10
+        };
+
+        var combos = config.GenerateCombinations();
+
+        Assert.NotEmpty(combos);
+        Assert.All(combos, p => Assert.Null(p.Seed));
+    }
+}

--- a/lucia.EvalHarness.Tests/ParameterSweepRunnerTests.cs
+++ b/lucia.EvalHarness.Tests/ParameterSweepRunnerTests.cs
@@ -140,7 +140,15 @@ public sealed class ParameterSweepRunnerTests
 
         await RunSweepAsync(runner, config, "baseline-model", ["target-model"]);
 
+        // Explicit BaseSeed = null must opt BOTH baseline and target runs out of
+        // seeding, not just the target sweep. Baseline runs previously fell back to
+        // ModelParameterProfile.Default (Seed = DefaultSeed), silently ignoring the opt-out.
+        var baselineCalls = callLog.Where(c => c.ModelName == "baseline-model").ToList();
         var targetCalls = callLog.Where(c => c.ModelName == "target-model").ToList();
+
+        Assert.NotEmpty(baselineCalls);
+        Assert.NotEmpty(targetCalls);
+        Assert.All(baselineCalls, c => Assert.Null(c.Profile.Seed));
         Assert.All(targetCalls, c => Assert.Null(c.Profile.Seed));
     }
 

--- a/lucia.EvalHarness/Configuration/ModelParameterProfile.cs
+++ b/lucia.EvalHarness/Configuration/ModelParameterProfile.cs
@@ -43,9 +43,17 @@ public sealed record ModelParameterProfile
     public double RepeatPenalty { get; init; } = 1.1;
 
     /// <summary>
-    /// Random seed for reproducibility. Null means non-deterministic.
+    /// Fixed seed used by all named profiles and default-constructed profiles so
+    /// that eval runs are reproducible without extra configuration. Callers that
+    /// need non-deterministic runs must explicitly set <see cref="Seed"/> to null.
     /// </summary>
-    public int? Seed { get; init; }
+    public const int DefaultSeed = 42;
+
+    /// <summary>
+    /// Random seed for reproducibility. Defaults to <see cref="DefaultSeed"/> so
+    /// every profile is deterministic unless explicitly overridden.
+    /// </summary>
+    public int? Seed { get; init; } = DefaultSeed;
 
     /// <summary>
     /// The default Ollama parameter profile matching Ollama's built-in defaults.

--- a/lucia.EvalHarness/Configuration/ParameterSweepConfig.cs
+++ b/lucia.EvalHarness/Configuration/ParameterSweepConfig.cs
@@ -59,9 +59,10 @@ public sealed class ParameterSweepConfig
     /// Optional base seed for deterministic sweeps. When set, each generated
     /// combination receives <c>Seed = BaseSeed + comboIndex * RunsPerCombination</c>,
     /// and the sweep runner offsets that by run index so every individual run is
-    /// reproducible yet distinct. When null (default), runs are non-deterministic.
+    /// reproducible yet distinct. Defaults to <see cref="ModelParameterProfile.DefaultSeed"/>
+    /// so sweeps are deterministic by default. Set to null to opt out of seeding.
     /// </summary>
-    public int? BaseSeed { get; set; }
+    public int? BaseSeed { get; set; } = ModelParameterProfile.DefaultSeed;
 
     /// <summary>
     /// Generates the parameter combinations to test, applying <see cref="MaxCombinations"/> limit.

--- a/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
+++ b/lucia.EvalHarness/Evaluation/ParameterSweepRunner.cs
@@ -157,11 +157,13 @@ public sealed class ParameterSweepRunner
         var baselineAllRuns = new List<IReadOnlyList<ModelEvalResult>>(runsPerCombination);
         for (var runIndex = 0; runIndex < runsPerCombination; runIndex++)
         {
-            // Derive a seed for each baseline run when BaseSeed is configured
-            var baselineRunProfile = sweepConfig.BaseSeed.HasValue
-                ? ModelParameterProfile.Default with
-                  { Seed = SweepRunAggregator.DeriveRunSeed(sweepConfig.BaseSeed, runIndex) }
-                : ModelParameterProfile.Default;
+            // Derive a per-run baseline seed. DeriveRunSeed returns null when
+            // BaseSeed is null, so an explicit caller opt-out propagates to the
+            // baseline runs too instead of falling back to the profile's default seed.
+            var baselineRunProfile = ModelParameterProfile.Default with
+            {
+                Seed = SweepRunAggregator.DeriveRunSeed(sweepConfig.BaseSeed, runIndex)
+            };
 
             var run = await EvalAsync(baselineModel, agentNames, testCaseLoader,
                 maxCasesPerAgent, baselineRunProfile, ct);


### PR DESCRIPTION
## Summary

Makes the eval parameter sweep deterministic by default while honouring an explicit non-deterministic opt-out on **every** run — baseline and target alike.

- **Fixed seed defaults** — named profiles (`Default`/`Precise`/`Creative`), default-constructed `ModelParameterProfile`, and `ParameterSweepConfig.BaseSeed` all default to the single-source-of-truth constant `ModelParameterProfile.DefaultSeed = 42`, so sweeps are reproducible without extra configuration.
- **Explicit null opt-out across baseline and targets** — a caller-provided `BaseSeed = null` now propagates to **both** the baseline runs and the target sweep runs. Previously the baseline branch fell back to `ModelParameterProfile.Default` (which carries `Seed = 42`), silently ignoring the documented opt-out; the target path already propagated null via `GenerateCombinations()`, so the two paths disagreed. The baseline profile now derives its per-run seed through `SweepRunAggregator.DeriveRunSeed(BaseSeed, runIndex)`, which returns `null` for a null base seed — preserving deterministic defaults for normal configs (`DeriveRunSeed(42, i)` = `42 + i`) while fixing the opt-out.
- **Regression test hardened** — `RunAsync_WithoutBaseSeed_ProfileSeedsAreNull` now asserts baseline call seeds are null in addition to target seeds. The prior test only checked target runs and did not catch the baseline fallback. Verified the test fails on the pre-fix runner (`baseline Seed = 42`) and passes after.

Scope boundary: does not absorb #130 (typed `ChatOptions` seed/temperature forwarding to providers) — only the configuration/propagation layer changes here.

## Validation

- **Tests:** `lucia.EvalHarness.Tests` 49/49 pass, 0 regressions (focused `ParameterSweepRunnerTests` 9/9).
- **Build:** `lucia.EvalHarness` Release — 0 warnings, 0 errors.
- **Strict Slopwatch** (`analyze --no-baseline --fail-on warning`, no baseline created): all findings are pre-existing debt in untouched files (e.g. `WyomingSessionIntegrationTests.cs`); **zero findings in the two changed files** — no new slop introduced.
- Untracked `.slopwatch/` generated files removed; no baseline committed; worktree clean.

Closes #132
