### PR TITLE
chore(telemetry): align ActivitySource names to lowercase ServiceDefaults registrations

### DIFF
--- a/lucia.Agents/Orchestration/AgentDispatchExecutor.cs
+++ b/lucia.Agents/Orchestration/AgentDispatchExecutor.cs
@@ -14,7 +14,7 @@ namespace lucia.Agents.Orchestration;
 /// </summary>
 public sealed class AgentDispatchExecutor : Executor
 {
-    private static readonly ActivitySource DispatchActivitySource = new("Lucia.AgentDispatch", "1.0.0");
+    private static readonly ActivitySource DispatchActivitySource = new("lucia.AgentDispatch", "1.0.0");
     private const string OriginalUserTextPropertyName = "lucia.originalUserText";
     private const string ClarificationSystemPrompt =
         """

--- a/lucia.Agents/Orchestration/OrchestrationTelemetry.cs
+++ b/lucia.Agents/Orchestration/OrchestrationTelemetry.cs
@@ -10,7 +10,7 @@ public static class OrchestrationTelemetry
     /// <summary>
     /// ActivitySource for orchestration tracing.
     /// </summary>
-    public static readonly ActivitySource Source = new("Lucia.Orchestration", "1.0.0");
+    public static readonly ActivitySource Source = new("lucia.Orchestration", "1.0.0");
     
     /// <summary>
     /// Standard tag names for orchestration activities.


### PR DESCRIPTION
OpenTelemetry 1.15.3 `AddSource` matching is OrdinalIgnoreCase, so export was never broken. This change only aligns two ActivitySource name literals with their existing `ServiceDefaults` registrations:

| File | Before | After | Registration |
|---|---|---|---|
| `OrchestrationTelemetry.cs` | `"Lucia.Orchestration"` | `"lucia.Orchestration"` | `"lucia.Orchestration"` |
| `AgentDispatchExecutor.cs` | `"Lucia.AgentDispatch"` | `"lucia.AgentDispatch"` | `"lucia.AgentDispatch"` |

No other sources were touched — many in the repo intentionally use uppercase prefixes.

**Validation**
- Build: `lucia.Agents` clean
- Tests: 3/3 `AgentDispatchExecutor` tests pass
- Slopwatch `--no-baseline --fail-on warning` on changed directory: 0 findings
- Tree clean; no generated artifacts

Closes #167