### PR TITLE
fix(eval): forward determinism knobs via typed ChatOptions

### DIFF
--- a/lucia.EvalHarness.Tests/Providers/OllamaWireParameterTests.cs
+++ b/lucia.EvalHarness.Tests/Providers/OllamaWireParameterTests.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using lucia.EvalHarness.Configuration;
+using lucia.EvalHarness.Providers;
+using lucia.EvalHarness.Tests.TestDoubles;
+using Microsoft.Extensions.AI;
+using OllamaSharp;
+
+namespace lucia.EvalHarness.Tests.Providers;
+
+/// <summary>
+/// Wire-level tests that run the real installed OllamaSharp <see cref="OllamaApiClient"/> adapter
+/// against a fake <see cref="System.Net.Http.HttpMessageHandler"/>, asserting on the exact
+/// <c>options</c> object that OllamaSharp serializes for the <c>/api/chat</c> request. This proves
+/// the determinism knobs survive the real M.E.AI → OllamaSharp mapping onto the wire.
+/// </summary>
+public class OllamaWireParameterTests
+{
+    private const string ValidChatResponse =
+        "{\"model\":\"test-model\",\"created_at\":\"2024-01-01T00:00:00.0000000Z\"," +
+        "\"message\":{\"role\":\"assistant\",\"content\":\"hi\"}," +
+        "\"done\":true,\"done_reason\":\"stop\"," +
+        "\"total_duration\":1000,\"load_duration\":1000," +
+        "\"prompt_eval_count\":1,\"prompt_eval_duration\":1000," +
+        "\"eval_count\":1,\"eval_duration\":1000}";
+
+    private static ModelParameterProfile Profile(
+        int numPredict = -1,
+        double repeatPenalty = 1.1,
+        int? seed = 42) => new()
+    {
+        Name = "test",
+        NumPredict = numPredict,
+        RepeatPenalty = repeatPenalty,
+        Seed = seed
+    };
+
+    private static async Task<JsonElement> SendAndCaptureOptionsAsync(
+        ModelParameterProfile profile,
+        ChatOptions? caller = null)
+    {
+        var handler = new CapturingHttpMessageHandler(ValidChatResponse);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:11434") };
+        using var inner = new OllamaApiClient(http, "test-model");
+        var client = new ParameterInjectingChatClient(inner, profile);
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")], caller);
+
+        return handler.CapturedRoot.GetProperty("options");
+    }
+
+    [Fact]
+    public async Task TypedSeed_IsWiredToOllamaSeed()
+    {
+        var options = await SendAndCaptureOptionsAsync(Profile(seed: 42));
+
+        Assert.Equal(42, options.GetProperty("seed").GetInt32());
+    }
+
+    [Fact]
+    public async Task CallerSeed_TakesPrecedenceOnWire()
+    {
+        var options = await SendAndCaptureOptionsAsync(Profile(seed: 42), new ChatOptions { Seed = 999 });
+
+        Assert.Equal(999, options.GetProperty("seed").GetInt32());
+    }
+
+    [Fact]
+    public async Task PositiveNumPredict_IsWiredToOllamaNumPredict()
+    {
+        var options = await SendAndCaptureOptionsAsync(Profile(numPredict: 128));
+
+        Assert.Equal(128, options.GetProperty("num_predict").GetInt32());
+    }
+
+    [Fact]
+    public async Task UnlimitedNumPredict_IsWiredAsNegativeOne()
+    {
+        var options = await SendAndCaptureOptionsAsync(Profile(numPredict: -1));
+
+        Assert.Equal(-1, options.GetProperty("num_predict").GetInt32());
+    }
+
+    [Fact]
+    public async Task UnlimitedNumPredict_DoesNotOverrideCallerTypedLimitOnWire()
+    {
+        var options = await SendAndCaptureOptionsAsync(
+            Profile(numPredict: -1),
+            new ChatOptions { MaxOutputTokens = 200 });
+
+        // Caller's typed cap must survive; the -1 sentinel must not clobber it.
+        Assert.Equal(200, options.GetProperty("num_predict").GetInt32());
+    }
+
+    [Fact]
+    public async Task RepeatPenalty_IsWiredToOllamaRepeatPenalty()
+    {
+        var options = await SendAndCaptureOptionsAsync(Profile(repeatPenalty: 1.3));
+
+        Assert.Equal(1.3f, options.GetProperty("repeat_penalty").GetSingle(), 3);
+    }
+
+    [Fact]
+    public async Task NoFrequencyPenalty_IsEmittedOnWire()
+    {
+        var options = await SendAndCaptureOptionsAsync(Profile());
+
+        Assert.False(options.TryGetProperty("frequency_penalty", out _));
+    }
+}

--- a/lucia.EvalHarness.Tests/Providers/OpenAIWireParameterTests.cs
+++ b/lucia.EvalHarness.Tests/Providers/OpenAIWireParameterTests.cs
@@ -1,0 +1,110 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+using lucia.EvalHarness.Configuration;
+using lucia.EvalHarness.Providers;
+using lucia.EvalHarness.Tests.TestDoubles;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+namespace lucia.EvalHarness.Tests.Providers;
+
+/// <summary>
+/// Wire-level tests that run the real installed OpenAI SDK <see cref="ChatClient"/> adapter against
+/// a fake transport, asserting on the exact JSON body of the <c>/chat/completions</c> request. This
+/// proves determinism knobs are wired via typed fields for OpenAI-compatible backends and that the
+/// Ollama-specific additional properties never leak onto an OpenAI request.
+/// </summary>
+public class OpenAIWireParameterTests
+{
+    private const string ValidChatResponse =
+        "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1700000000," +
+        "\"model\":\"test-model\",\"choices\":[{\"index\":0," +
+        "\"message\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":\"stop\"}]," +
+        "\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":1}}";
+
+    private static ModelParameterProfile Profile(
+        int numPredict = -1,
+        double repeatPenalty = 1.1,
+        int? seed = 42) => new()
+    {
+        Name = "test",
+        NumPredict = numPredict,
+        RepeatPenalty = repeatPenalty,
+        Seed = seed
+    };
+
+    private static async Task<JsonElement> SendAndCaptureBodyAsync(
+        ModelParameterProfile profile,
+        ChatOptions? caller = null)
+    {
+        var handler = new CapturingHttpMessageHandler(ValidChatResponse);
+        using var http = new HttpClient(handler);
+        var options = new OpenAIClientOptions
+        {
+            Endpoint = new Uri("http://localhost:1234/v1"),
+            Transport = new HttpClientPipelineTransport(http)
+        };
+        var openAiClient = new OpenAIClient(new ApiKeyCredential("not-needed"), options);
+        var inner = openAiClient.GetChatClient("test-model").AsIChatClient();
+        var client = new ParameterInjectingChatClient(inner, profile);
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")], caller);
+
+        return handler.CapturedRoot;
+    }
+
+    [Fact]
+    public async Task TypedSeed_IsWiredToOpenAISeed()
+    {
+        var body = await SendAndCaptureBodyAsync(Profile(seed: 42));
+
+        Assert.Equal(42, body.GetProperty("seed").GetInt32());
+    }
+
+    [Fact]
+    public async Task CallerSeed_TakesPrecedenceOnWire()
+    {
+        var body = await SendAndCaptureBodyAsync(Profile(seed: 42), new ChatOptions { Seed = 999 });
+
+        Assert.Equal(999, body.GetProperty("seed").GetInt32());
+    }
+
+    [Fact]
+    public async Task PositiveNumPredict_IsWiredToMaxCompletionTokens()
+    {
+        var body = await SendAndCaptureBodyAsync(Profile(numPredict: 128));
+
+        Assert.Equal(128, body.GetProperty("max_completion_tokens").GetInt32());
+    }
+
+    [Fact]
+    public async Task UnlimitedNumPredict_DoesNotEmitAnyTokenLimit()
+    {
+        var body = await SendAndCaptureBodyAsync(Profile(numPredict: -1));
+
+        // -1 is Ollama's unlimited sentinel; OpenAI must never receive a token-limit field for it.
+        Assert.False(body.TryGetProperty("max_completion_tokens", out _));
+        Assert.False(body.TryGetProperty("max_tokens", out _));
+    }
+
+    [Fact]
+    public async Task ZeroNumPredict_DoesNotEmitAnyTokenLimit()
+    {
+        var body = await SendAndCaptureBodyAsync(Profile(numPredict: 0));
+
+        Assert.False(body.TryGetProperty("max_completion_tokens", out _));
+        Assert.False(body.TryGetProperty("max_tokens", out _));
+    }
+
+    [Fact]
+    public async Task OllamaSpecificKeys_NeverLeakOntoOpenAIRequest()
+    {
+        var body = await SendAndCaptureBodyAsync(Profile(numPredict: -1, repeatPenalty: 1.3));
+
+        Assert.False(body.TryGetProperty("num_predict", out _));
+        Assert.False(body.TryGetProperty("repeat_penalty", out _));
+        // RepeatPenalty must not be smuggled through the typed FrequencyPenalty either.
+        Assert.False(body.TryGetProperty("frequency_penalty", out _));
+    }
+}

--- a/lucia.EvalHarness.Tests/Providers/ParameterInjectingChatClientTests.cs
+++ b/lucia.EvalHarness.Tests/Providers/ParameterInjectingChatClientTests.cs
@@ -1,0 +1,168 @@
+using lucia.EvalHarness.Configuration;
+using lucia.EvalHarness.Providers;
+using lucia.EvalHarness.Tests.TestDoubles;
+using Microsoft.Extensions.AI;
+
+namespace lucia.EvalHarness.Tests.Providers;
+
+/// <summary>
+/// Provider-free tests that assert how <see cref="ParameterInjectingChatClient"/> maps a
+/// <see cref="ModelParameterProfile"/> onto <see cref="ChatOptions"/>, captured verbatim by a
+/// generic <see cref="CapturingChatClient"/> double.
+/// </summary>
+public class ParameterInjectingChatClientTests
+{
+    private static ModelParameterProfile Profile(
+        int numPredict = -1,
+        double repeatPenalty = 1.1,
+        int? seed = 42) => new()
+    {
+        Name = "test",
+        NumPredict = numPredict,
+        RepeatPenalty = repeatPenalty,
+        Seed = seed
+    };
+
+    private static async Task<ChatOptions> CaptureAsync(ModelParameterProfile profile, ChatOptions? caller)
+    {
+        var capture = new CapturingChatClient();
+        var client = new ParameterInjectingChatClient(capture, profile);
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")], caller);
+        return capture.CapturedOptions!;
+    }
+
+    [Fact]
+    public async Task Seed_FillsTypedSeed_FromProfile()
+    {
+        var options = await CaptureAsync(Profile(seed: 42), caller: null);
+
+        Assert.Equal(42L, options.Seed);
+        // Seed must never be smuggled through additional properties.
+        Assert.False(options.AdditionalProperties?.ContainsKey("seed") ?? false);
+    }
+
+    [Fact]
+    public async Task Seed_CallerValueWins()
+    {
+        var caller = new ChatOptions { Seed = 999 };
+
+        var options = await CaptureAsync(Profile(seed: 42), caller);
+
+        Assert.Equal(999L, options.Seed);
+    }
+
+    [Fact]
+    public async Task NumPredictPositive_FillsTypedMaxOutputTokens()
+    {
+        var options = await CaptureAsync(Profile(numPredict: 128), caller: null);
+
+        Assert.Equal(128, options.MaxOutputTokens);
+        Assert.False(options.AdditionalProperties?.ContainsKey("num_predict") ?? false);
+    }
+
+    [Fact]
+    public async Task NumPredictPositive_CallerMaxOutputTokensWins()
+    {
+        var caller = new ChatOptions { MaxOutputTokens = 64 };
+
+        var options = await CaptureAsync(Profile(numPredict: 128), caller);
+
+        Assert.Equal(64, options.MaxOutputTokens);
+    }
+
+    [Fact]
+    public async Task NumPredictZero_OmitsTokenLimitEntirely()
+    {
+        var options = await CaptureAsync(Profile(numPredict: 0), caller: null);
+
+        Assert.Null(options.MaxOutputTokens);
+        Assert.False(options.AdditionalProperties?.ContainsKey("num_predict") ?? false);
+    }
+
+    [Fact]
+    public async Task NumPredictUnlimited_AddsProviderNumPredictKey()
+    {
+        var options = await CaptureAsync(Profile(numPredict: -1), caller: null);
+
+        Assert.Null(options.MaxOutputTokens);
+        Assert.Equal(-1, Assert.IsType<int>(options.AdditionalProperties!["num_predict"]));
+    }
+
+    [Fact]
+    public async Task NumPredictUnlimited_DoesNotOverrideCallerTypedLimit()
+    {
+        var caller = new ChatOptions { MaxOutputTokens = 200 };
+
+        var options = await CaptureAsync(Profile(numPredict: -1), caller);
+
+        Assert.Equal(200, options.MaxOutputTokens);
+        Assert.False(options.AdditionalProperties?.ContainsKey("num_predict") ?? false);
+    }
+
+    [Fact]
+    public async Task NumPredictUnlimited_DoesNotOverrideCallerProviderKey()
+    {
+        var caller = new ChatOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { ["num_predict"] = 50 }
+        };
+
+        var options = await CaptureAsync(Profile(numPredict: -1), caller);
+
+        Assert.Equal(50, Assert.IsType<int>(options.AdditionalProperties!["num_predict"]));
+    }
+
+    [Fact]
+    public async Task RepeatPenalty_AddedAsProviderKey_NeverFrequencyPenalty()
+    {
+        var options = await CaptureAsync(Profile(repeatPenalty: 1.3), caller: null);
+
+        Assert.Equal(1.3f, Assert.IsType<float>(options.AdditionalProperties!["repeat_penalty"]));
+        Assert.Null(options.FrequencyPenalty);
+    }
+
+    [Fact]
+    public async Task RepeatPenalty_CallerValueWins()
+    {
+        var caller = new ChatOptions
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary { ["repeat_penalty"] = 2.0f }
+        };
+
+        var options = await CaptureAsync(Profile(repeatPenalty: 1.3), caller);
+
+        Assert.Equal(2.0f, Assert.IsType<float>(options.AdditionalProperties!["repeat_penalty"]));
+    }
+
+    [Fact]
+    public async Task UnrelatedProperties_ArePreserved()
+    {
+        var caller = new ChatOptions
+        {
+            ModelId = "custom-model",
+            AdditionalProperties = new AdditionalPropertiesDictionary { ["keep_alive"] = "10m" }
+        };
+
+        var options = await CaptureAsync(Profile(), caller);
+
+        Assert.Equal("custom-model", options.ModelId);
+        Assert.Equal("10m", options.AdditionalProperties!["keep_alive"]);
+    }
+
+    [Fact]
+    public async Task StreamingPath_AppliesSameMapping()
+    {
+        var capture = new CapturingChatClient();
+        var client = new ParameterInjectingChatClient(capture, Profile(numPredict: 128, seed: 7));
+
+        await foreach (var _ in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hi")]))
+        {
+            // drain
+        }
+
+        var options = capture.CapturedOptions!;
+        Assert.Equal(7L, options.Seed);
+        Assert.Equal(128, options.MaxOutputTokens);
+        Assert.Equal(1.1f, Assert.IsType<float>(options.AdditionalProperties!["repeat_penalty"]));
+    }
+}

--- a/lucia.EvalHarness.Tests/TestDoubles/CapturingChatClient.cs
+++ b/lucia.EvalHarness.Tests/TestDoubles/CapturingChatClient.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.AI;
+
+namespace lucia.EvalHarness.Tests.TestDoubles;
+
+/// <summary>
+/// Provider-agnostic <see cref="IChatClient"/> double that records the <see cref="ChatOptions"/>
+/// it receives from a <see cref="lucia.EvalHarness.Providers.ParameterInjectingChatClient"/>.
+/// Used to assert how determinism knobs are mapped onto <see cref="ChatOptions"/> without any
+/// real backend or protocol serialization.
+/// </summary>
+internal sealed class CapturingChatClient : IChatClient
+{
+    public ChatOptions? CapturedOptions { get; private set; }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        CapturedOptions = options;
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "ok")));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        CapturedOptions = options;
+        yield return new ChatResponseUpdate(ChatRole.Assistant, "ok");
+        await Task.CompletedTask;
+    }
+
+    public object? GetService(Type serviceType, object? key = null) => null;
+
+    public void Dispose() { }
+}

--- a/lucia.EvalHarness.Tests/TestDoubles/CapturingHttpMessageHandler.cs
+++ b/lucia.EvalHarness.Tests/TestDoubles/CapturingHttpMessageHandler.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Text.Json;
+
+namespace lucia.EvalHarness.Tests.TestDoubles;
+
+/// <summary>
+/// <see cref="HttpMessageHandler"/> that captures the outgoing request body of the first request
+/// it handles and replies with a fixed, valid response. Lets the real OllamaSharp / OpenAI
+/// <see cref="Microsoft.Extensions.AI.IChatClient"/> adapters run their full serialization path so
+/// tests can assert on the actual JSON that would hit the wire, without a live backend.
+/// </summary>
+internal sealed class CapturingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _responseJson;
+
+    public CapturingHttpMessageHandler(string responseJson)
+    {
+        _responseJson = responseJson;
+    }
+
+    /// <summary>The raw JSON body of the last captured request.</summary>
+    public string? CapturedBody { get; private set; }
+
+    /// <summary>The parsed root element of the last captured request body.</summary>
+    public JsonElement CapturedRoot { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Content is not null)
+        {
+            CapturedBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            using var doc = JsonDocument.Parse(CapturedBody);
+            CapturedRoot = doc.RootElement.Clone();
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(_responseJson, System.Text.Encoding.UTF8, "application/json")
+        };
+    }
+}

--- a/lucia.EvalHarness/Providers/ParameterInjectingChatClient.cs
+++ b/lucia.EvalHarness/Providers/ParameterInjectingChatClient.cs
@@ -4,11 +4,34 @@ using Microsoft.Extensions.AI;
 namespace lucia.EvalHarness.Providers;
 
 /// <summary>
-/// A delegating <see cref="IChatClient"/> that injects Ollama inference parameters
+/// A delegating <see cref="IChatClient"/> that injects determinism inference parameters
 /// from a <see cref="ModelParameterProfile"/> into every request's <see cref="ChatOptions"/>.
 /// </summary>
+/// <remarks>
+/// Determinism knobs are mapped to the strongly-typed M.E.AI fields whenever an equivalent
+/// exists, so that both the OllamaSharp and OpenAI <see cref="IChatClient"/> adapters forward
+/// them on the wire:
+/// <list type="bullet">
+///   <item><description><c>Seed</c> → typed <see cref="ChatOptions.Seed"/> (Ollama <c>seed</c>, OpenAI <c>seed</c>).</description></item>
+///   <item><description><c>NumPredict &gt; 0</c> → typed <see cref="ChatOptions.MaxOutputTokens"/> (Ollama <c>num_predict</c>, OpenAI <c>max_completion_tokens</c>).</description></item>
+///   <item><description><c>NumPredict == 0</c> → omitted (backend default applies).</description></item>
+///   <item><description><c>NumPredict == -1</c> (unlimited) → provider-specific <c>num_predict=-1</c> additional
+///     property, which OllamaSharp maps to unlimited generation while the OpenAI adapter ignores it
+///     (it never copies additional properties onto the wire). Only added when the caller supplied
+///     neither a typed <see cref="ChatOptions.MaxOutputTokens"/> nor a <c>num_predict</c> key, so a
+///     caller-provided token limit is never overridden.</description></item>
+///   <item><description><c>RepeatPenalty</c> → provider-specific <c>repeat_penalty</c> additional property
+///     (Ollama-only; <see cref="ChatOptions.FrequencyPenalty"/> is intentionally not used because it is a
+///     different penalty with different semantics).</description></item>
+/// </list>
+/// In every case the caller's own values win: typed fields are only filled when <see langword="null"/>
+/// and provider-specific keys are only added when absent. Unrelated options are preserved.
+/// </remarks>
 public sealed class ParameterInjectingChatClient : DelegatingChatClient
 {
+    private const string NumPredictKey = "num_predict";
+    private const string RepeatPenaltyKey = "repeat_penalty";
+
     private readonly ModelParameterProfile _profile;
 
     public ParameterInjectingChatClient(IChatClient innerClient, ModelParameterProfile profile)
@@ -42,16 +65,34 @@ public sealed class ParameterInjectingChatClient : DelegatingChatClient
         options.TopK ??= _profile.TopK;
         options.TopP ??= (float)_profile.TopP;
 
+        // Seed: strongly typed so both Ollama and OpenAI adapters wire it. Caller wins.
+        options.Seed ??= _profile.Seed;
+
+        // Positive NumPredict is a real token cap → strongly typed MaxOutputTokens.
+        // Ollama maps it to num_predict; OpenAI maps it to max_completion_tokens. Caller wins.
+        if (_profile.NumPredict > 0)
+            options.MaxOutputTokens ??= _profile.NumPredict;
+
         options.AdditionalProperties ??= [];
 
-        if (!options.AdditionalProperties.ContainsKey("num_predict"))
-            options.AdditionalProperties["num_predict"] = _profile.NumPredict;
+        // RepeatPenalty has no strongly-typed M.E.AI equivalent (FrequencyPenalty is a different
+        // knob), so it is provider-specific. OllamaSharp reads the "repeat_penalty" key; the OpenAI
+        // adapter never copies additional properties onto the wire, so it is silently ignored there.
+        if (!options.AdditionalProperties.ContainsKey(RepeatPenaltyKey))
+            options.AdditionalProperties[RepeatPenaltyKey] = (float)_profile.RepeatPenalty;
 
-        if (!options.AdditionalProperties.ContainsKey("repeat_penalty"))
-            options.AdditionalProperties["repeat_penalty"] = _profile.RepeatPenalty;
-
-        if (_profile.Seed.HasValue && !options.AdditionalProperties.ContainsKey("seed"))
-            options.AdditionalProperties["seed"] = _profile.Seed.Value;
+        // NumPredict == -1 means "unlimited" for Ollama, which cannot be expressed via the typed
+        // MaxOutputTokens (a non-negative token count). Emit it as the provider-specific num_predict
+        // key so OllamaSharp preserves unlimited generation, but only when the caller supplied neither
+        // a typed token limit nor their own num_predict — otherwise we would override the caller's cap.
+        // The OpenAI adapter ignores this key, so nothing negative leaks onto an OpenAI request.
+        // NumPredict == 0 is intentionally omitted entirely (the backend default applies).
+        if (_profile.NumPredict == -1
+            && options.MaxOutputTokens is null
+            && !options.AdditionalProperties.ContainsKey(NumPredictKey))
+        {
+            options.AdditionalProperties[NumPredictKey] = -1;
+        }
 
         return options;
     }


### PR DESCRIPTION
## Summary

Eval determinism knobs (`seed`, `num_predict`, `repeat_penalty`) were written into `ChatOptions.AdditionalProperties` as loose string keys. The OllamaSharp and OpenAI `IChatClient` adapters only map the strongly-typed M.E.AI fields, so `seed` and token limits were silently dropped before reaching the backend — making eval sweeps non-reproducible even with a fixed seed.

`ParameterInjectingChatClient` now maps each knob to its verified wire boundary:

| Profile | Action | Ollama wire | OpenAI wire |
|---|---|---|---|
| `Seed` | `options.Seed ??=` (typed, caller wins) | `seed` | `seed` |
| `NumPredict > 0` | `MaxOutputTokens ??=` | `num_predict` | `max_completion_tokens` |
| `NumPredict == 0` | omitted | — | — |
| `NumPredict == -1` | provider `num_predict=-1`, only when caller set neither a typed limit nor their own `num_predict` | `num_predict:-1` (unlimited) | ignored (never leaks) |
| `RepeatPenalty` | provider `repeat_penalty` (caller precedence; never `FrequencyPenalty`) | `repeat_penalty` | ignored |

Caller values always win: typed fields fill only when `null`, provider keys add only when absent. Unrelated options are preserved.

## Wire boundaries verified (ILSpy, installed packages)

- **OllamaSharp 5.4.25** `AbstractionMapper.ToOllamaSharpChatRequest`: typed `Seed -> "seed"`, `MaxOutputTokens -> NumPredict -> "num_predict"`; additional-property keys `num_predict`/`repeat_penalty`/`seed` override typed values.
- **Microsoft.Extensions.AI.OpenAI 10.6.0** `OpenAIChatClient.ToOpenAIOptions`: typed `Seed -> "seed"`, `MaxOutputTokens -> "max_completion_tokens"`; additional properties are never serialized onto the wire, so Ollama-specific keys can't leak.

## Tests

Provider-free TDD, 25 new tests (57/57 in the project pass):

- **Generic capture** — typed seed, seed caller precedence, `+`/`0`/`-1` tokens, typed/provider-key precedence, repeat/unrelated preservation, streaming parity.
- **Ollama HTTP wire** — real `OllamaApiClient` + fake handler assert `seed`, `num_predict` (`+`/`-1`), typed-limit-vs-`-1` conflict, `repeat_penalty`, and absence of `frequency_penalty`.
- **OpenAI wire** — real `OpenAIClient` + fake transport assert `seed`/caller seed, `max_completion_tokens`, no token field for `0`/`-1`, and no leaked `num_predict`/`repeat_penalty`/`frequency_penalty`.

Fixes #130
