### PR TITLE
fix(hosting): gate OpenAPI and Scalar API docs to Development

### DIFF
--- a/.docs/product/tech-stack.md
+++ b/.docs/product/tech-stack.md
@@ -92,6 +92,7 @@
 - **Framework:** xUnit
 - **Mocking:** FakeItEasy
 - **Integration:** Aspire.Hosting.Testing
+- **Host integration:** Microsoft.AspNetCore.Mvc.Testing (WebApplicationFactory) for in-process host-boot tests
 
 ### CI/CD Pipeline
 - **Platform:** GitHub Actions

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -131,6 +131,7 @@
   <ItemGroup Label="Testing">
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />

--- a/lucia.A2AHost/Program.cs
+++ b/lucia.A2AHost/Program.cs
@@ -187,10 +187,13 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 
+    // Scalar API reference is development-only; production security comes from
+    // route absence rather than runtime authorization checks.
+    app.MapScalarApiReference();
+
     app.UseHttpsRedirection();
 }
 
-app.MapScalarApiReference();
 app.UseForwardedHeaders();
 
 app.MapAgentPlugins();

--- a/lucia.AgentHost/Program.cs
+++ b/lucia.AgentHost/Program.cs
@@ -418,10 +418,16 @@ await using (var seedScope = app.Services.CreateAsyncScope())
 foreach (var initializable in app.Services.GetServices<IAsyncInitializable>())
     await initializable.InitializeAsync(CancellationToken.None).ConfigureAwait(false);
 
-app.MapOpenApi()
-    .CacheOutput();
+// API documentation (OpenAPI + Scalar) is development-only. In non-development
+// environments these routes are never mapped, so production security comes from
+// route absence rather than runtime authorization checks.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi()
+        .CacheOutput();
 
-app.MapScalarApiReference();
+    app.MapScalarApiReference();
+}
 
 app.UseForwardedHeaders();
 app.UseAntiforgery();

--- a/lucia.Tests/Hosting/A2AHostApiDocsGatingTests.cs
+++ b/lucia.Tests/Hosting/A2AHostApiDocsGatingTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using lucia.A2AHost.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace lucia.Tests.Hosting;
+
+/// <summary>
+/// Boots the actual <c>lucia.A2AHost</c> assembly in-process and verifies that the
+/// OpenAPI and Scalar API-documentation routes are mapped only in the Development
+/// environment. In Production the routes must be absent (404); this is the security
+/// guarantee (production hardening comes from route absence). The tests execute the
+/// real top-level Program and fail if the environment guards are removed.
+/// </summary>
+public sealed class A2AHostApiDocsGatingTests
+{
+    private const string OpenApiRoute = "/openapi/v1.json";
+    private const string ScalarRoute = "/scalar/v1";
+
+    private static readonly WebApplicationFactoryClientOptions ClientOptions = new()
+    {
+        AllowAutoRedirect = false,
+    };
+
+    [Fact]
+    public async Task Production_OpenApiRoute_IsAbsent()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentHostService>("Production");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(OpenApiRoute);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Production_ScalarRoute_IsAbsent()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentHostService>("Production");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(ScalarRoute);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Development_OpenApiRoute_IsMapped()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentHostService>("Development");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(OpenApiRoute);
+
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Development_ScalarRoute_IsMapped()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentHostService>("Development");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(ScalarRoute);
+
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/lucia.Tests/Hosting/AgentHostApiDocsGatingTests.cs
+++ b/lucia.Tests/Hosting/AgentHostApiDocsGatingTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using lucia.AgentHost.Apis;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace lucia.Tests.Hosting;
+
+/// <summary>
+/// Boots the actual <c>lucia.AgentHost</c> assembly in-process and verifies that
+/// the OpenAPI and Scalar API-documentation routes are mapped only in the
+/// Development environment. In Production the routes must be absent (404); this is
+/// the security guarantee (production hardening comes from route absence). The
+/// tests execute the real top-level Program and fail if the environment guards are
+/// removed.
+/// </summary>
+public sealed class AgentHostApiDocsGatingTests
+{
+    private const string OpenApiRoute = "/openapi/v1.json";
+    private const string ScalarRoute = "/scalar/v1";
+
+    private static readonly WebApplicationFactoryClientOptions ClientOptions = new()
+    {
+        AllowAutoRedirect = false,
+    };
+
+    [Fact]
+    public async Task Production_OpenApiRoute_IsAbsent()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentInfo>("Production");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(OpenApiRoute);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Production_ScalarRoute_IsAbsent()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentInfo>("Production");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(ScalarRoute);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Development_OpenApiRoute_IsMapped()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentInfo>("Development");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(OpenApiRoute);
+
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Development_ScalarRoute_IsMapped()
+    {
+        using var factory = new ApiDocsGatingFactory<AgentInfo>("Development");
+        using var client = factory.CreateClient(ClientOptions);
+
+        var response = await client.GetAsync(ScalarRoute);
+
+        Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/lucia.Tests/Hosting/ApiDocsGatingFactory.cs
+++ b/lucia.Tests/Hosting/ApiDocsGatingFactory.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace lucia.Tests.Hosting;
+
+/// <summary>
+/// Boots an actual host assembly (identified by <typeparamref name="TEntryPoint"/>)
+/// in-process under a specified environment, overriding only the configuration
+/// required to run offline: lightweight InMemory cache + SQLite store, an empty
+/// plugin directory, and placeholder Home Assistant settings. No Redis, MongoDB,
+/// or real HTTP dependencies are contacted. Used to prove that API documentation
+/// routes (<c>/openapi/*</c> and <c>/scalar/*</c>) are development-only.
+/// </summary>
+internal sealed class ApiDocsGatingFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint>
+    where TEntryPoint : class
+{
+    private readonly string _environment;
+    private readonly string _dataRoot;
+
+    public ApiDocsGatingFactory(string environment)
+    {
+        _environment = environment;
+        _dataRoot = Path.Combine(AppContext.BaseDirectory, "apidocs-gating", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_dataRoot, "plugins"));
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        // The overrides go into host configuration because the actual top-level
+        // Program reads these keys inline while constructing the builder (choosing
+        // the data provider, plugin directory, and registry URL). Host configuration
+        // is applied early enough to be visible at that point, whereas app
+        // configuration added by the test host is not.
+        builder.UseEnvironment(_environment);
+
+        // These tests assert only that the API-documentation routes are gated to
+        // Development; they are not a check of the hosts' dependency-injection
+        // graphs. The Development environment turns on build-time container
+        // validation, which would otherwise abort the boot on pre-existing,
+        // unrelated service-registration gaps in a host rather than on anything
+        // touched by this change. Disable it so the boot mirrors the provider
+        // behavior the hosts use in Production and the route assertions can run.
+        builder.UseDefaultServiceProvider((_, options) =>
+        {
+            options.ValidateOnBuild = false;
+            options.ValidateScopes = false;
+        });
+
+        builder.ConfigureHostConfiguration(config =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [HostDefaults.EnvironmentKey] = _environment,
+                ["DataProvider:Cache"] = "InMemory",
+                ["DataProvider:Store"] = "SQLite",
+                ["DataProvider:SqlitePath"] = Path.Combine(_dataRoot, "lucia.db"),
+                ["PluginDirectory"] = Path.Combine(_dataRoot, "plugins"),
+                // Bind the Wyoming voice TCP listener to an ephemeral port so that
+                // multiple in-process host boots never collide on the fixed default.
+                ["Wyoming:Port"] = "0",
+                // Placeholder Home Assistant settings so hosts that block startup
+                // until HA is configured proceed immediately without contacting it.
+                ["HomeAssistant:BaseUrl"] = "http://127.0.0.1:9",
+                ["HomeAssistant:AccessToken"] = "integration-test-token",
+                // Point registry lookups at a closed port so any stray attempt
+                // fails fast rather than resolving a real DNS name.
+                ["services:registryApi"] = "http://127.0.0.1:9",
+            });
+        });
+
+        return base.CreateHost(builder);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (!disposing)
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(_dataRoot, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort cleanup; the SQLite file may still be locked briefly.
+            Debug.WriteLine($"ApiDocsGatingFactory temp cleanup skipped: {ex.Message}");
+        }
+    }
+}

--- a/lucia.Tests/lucia.Tests.csproj
+++ b/lucia.Tests/lucia.Tests.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
@@ -72,6 +73,7 @@
     <ProjectReference Include="..\lucia.TimerAgent\lucia.TimerAgent.csproj" />
     <ProjectReference Include="..\lucia.Wyoming\lucia.Wyoming.csproj" />
     <ProjectReference Include="..\lucia.Data\lucia.Data.csproj" />
+    <ProjectReference Include="..\lucia.A2AHost\lucia.A2AHost.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="AgentTests\" />


### PR DESCRIPTION
Gates the OpenAPI and Scalar API-documentation surfaces to the Development environment on both hosts.

## Problem
- `lucia.AgentHost` mapped `/openapi` and `/scalar` unconditionally.
- `lucia.A2AHost` mapped `/scalar` outside its existing Development-only block.

Both API-docs surfaces were therefore reachable in Production.

## Change
- Wrap the AgentHost `MapOpenApi().CacheOutput()` + `MapScalarApiReference()` in an `app.Environment.IsDevelopment()` guard.
- Move the A2AHost `MapScalarApiReference()` into its existing Development block.
- Security comes from route absence in Production; onboarding auth exemptions are unchanged. No behavior added or removed elsewhere.

## Tests
Authentic in-process integration tests boot each real host assembly (via existing public marker types `AgentInfo` and `AgentHostService`) and hit the real `/openapi/v1.json` and `/scalar/v1` routes:
- Production returns 404; Development returns 200.
- A shared `WebApplicationFactory` boots offline (InMemory cache, SQLite, empty plugin dir, placeholder Home Assistant settings, ephemeral Wyoming port) and relaxes build-time DI validation so an unrelated, pre-existing A2AHost registration gap does not block the route assertions.

Adds the test-only `Microsoft.AspNetCore.Mvc.Testing` package via CPM (shared ASP.NET Core version) and a `lucia.A2AHost` project reference.

## Validation
- Build: succeeds, 0 warnings/errors.
- Focused tests: 8/8 pass.
- Slopwatch (`--no-baseline --fail-on warning`): only 2 pre-existing `SW005` `<NoWarn>` findings, untouched by this diff.

Fixes #169