### PR TITLE
fix: enforce async deadlines across timer, websocket, and eval LLM sites

### DIFF
--- a/lucia.EvalHarness.Tests/HarnessConfigurationValidationTests.cs
+++ b/lucia.EvalHarness.Tests/HarnessConfigurationValidationTests.cs
@@ -1,0 +1,45 @@
+using lucia.EvalHarness.Configuration;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Verifies that <see cref="HarnessConfiguration.Validate"/> rejects non-positive
+/// deadline values instead of silently disabling the timeout.
+/// </summary>
+public sealed class HarnessConfigurationValidationTests
+{
+    [Fact]
+    public void Validate_DefaultConfiguration_Passes()
+    {
+        var config = new HarnessConfiguration();
+
+        config.Validate();
+
+        Assert.True(config.AgentTimeout > TimeSpan.Zero);
+        Assert.True(config.JudgeTimeout > TimeSpan.Zero);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-300)]
+    public void Validate_NonPositiveAgentTimeout_Throws(int seconds)
+    {
+        var config = new HarnessConfiguration { AgentTimeoutSeconds = seconds };
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("AgentTimeoutSeconds", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-120)]
+    public void Validate_NonPositiveJudgeTimeout_Throws(int seconds)
+    {
+        var config = new HarnessConfiguration { JudgeTimeoutSeconds = seconds };
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("JudgeTimeoutSeconds", ex.Message);
+    }
+}

--- a/lucia.EvalHarness.Tests/LlmDeadlineTests.cs
+++ b/lucia.EvalHarness.Tests/LlmDeadlineTests.cs
@@ -1,0 +1,75 @@
+using lucia.EvalHarness.Infrastructure;
+using Microsoft.Extensions.Time.Testing;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Deterministic tests for <see cref="LlmDeadline"/>, which backs the per-call
+/// timeout applied to every eval-harness LLM site. Uses <see cref="FakeTimeProvider"/>
+/// to fire the deadline while an operation is genuinely in-flight (not a pre-cancel).
+/// </summary>
+public sealed class LlmDeadlineTests
+{
+    [Fact]
+    public async Task RunAsync_InternalTimeoutFiresWhileInFlight_ThrowsTimeoutException()
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        var task = LlmDeadline.RunAsync<int>(
+            BlockUntilCanceledAsync,
+            TimeSpan.FromSeconds(120),
+            timeProvider,
+            CancellationToken.None,
+            "op timed out");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(121));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => task);
+    }
+
+    [Fact]
+    public async Task RunAsync_CallerCancels_PropagatesOperationCanceled_NotTimeout()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var caller = new CancellationTokenSource();
+
+        var task = LlmDeadline.RunAsync<int>(
+            BlockUntilCanceledAsync,
+            TimeSpan.FromSeconds(120),
+            timeProvider,
+            caller.Token,
+            "op timed out");
+
+        caller.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task RunAsync_OperationCompletesBeforeDeadline_ReturnsResult()
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        var result = await LlmDeadline.RunAsync<int>(
+            _ => Task.FromResult(11),
+            TimeSpan.FromSeconds(120),
+            timeProvider,
+            CancellationToken.None,
+            "op timed out");
+
+        Assert.Equal(11, result);
+    }
+
+    /// <summary>
+    /// Deterministic stand-in for an in-flight operation: completes only when the
+    /// supplied token is canceled (by the deadline or the caller), throwing
+    /// <see cref="OperationCanceledException"/>. Uses a <see cref="TaskCompletionSource{TResult}"/>
+    /// rather than <c>Task.Delay</c> so no wall-clock time is involved.
+    /// </summary>
+    private static async Task<int> BlockUntilCanceledAsync(CancellationToken token)
+    {
+        var tcs = new TaskCompletionSource<int>();
+        await using var registration = token.Register(() => tcs.TrySetCanceled(token));
+        return await tcs.Task;
+    }
+}

--- a/lucia.EvalHarness.Tests/PersonalityEvalReportTests.cs
+++ b/lucia.EvalHarness.Tests/PersonalityEvalReportTests.cs
@@ -1,0 +1,89 @@
+using lucia.EvalHarness.Personality;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Verifies that a judge timeout (a <see cref="JudgeResult"/> with zero scores and
+/// <see cref="JudgeResult.TimedOut"/> set) is excluded from score/failure aggregation
+/// in <see cref="PersonalityEvalReport"/> and surfaced separately as a timeout.
+/// </summary>
+public sealed class PersonalityEvalReportTests
+{
+    private static PersonalityScenarioResult Scored(int personality, int meaning) => new()
+    {
+        ScenarioId = "s-scored",
+        ScenarioDescription = "scored",
+        Category = "test",
+        ProfileId = "p1",
+        ProfileName = "Profile 1",
+        ModelName = "model",
+        Score = (personality + meaning) / 2.0,
+        LlmResponse = "ok",
+        DurationMs = 10,
+        JudgeResult = new JudgeResult
+        {
+            PersonalityScore = personality,
+            PersonalityReason = "reason",
+            MeaningScore = meaning,
+            MeaningReason = "reason"
+        }
+    };
+
+    private static PersonalityScenarioResult JudgeTimedOut() => new()
+    {
+        ScenarioId = "s-timeout",
+        ScenarioDescription = "timeout",
+        Category = "test",
+        ProfileId = "p1",
+        ProfileName = "Profile 1",
+        ModelName = "model",
+        Score = 0,
+        LlmResponse = "ok",
+        DurationMs = 10,
+        TimedOut = true,
+        JudgeResult = new JudgeResult
+        {
+            PersonalityScore = 0,
+            PersonalityReason = "Judge call timed out",
+            MeaningScore = 0,
+            MeaningReason = "Judge call timed out",
+            TimedOut = true
+        }
+    };
+
+    private static PersonalityEvalReport Report(params PersonalityScenarioResult[] results) => new()
+    {
+        ModelName = "model",
+        JudgeModelName = "judge",
+        Results = results,
+        StartedAt = DateTimeOffset.UtcNow,
+        CompletedAt = DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public void Averages_ExcludeTimedOutJudgeResults()
+    {
+        var report = Report(Scored(4, 4), JudgeTimedOut());
+
+        Assert.Equal(4.0, report.AveragePersonalityScore);
+        Assert.Equal(4.0, report.AverageMeaningScore);
+        Assert.Equal(4.0, report.AverageCombinedScore);
+    }
+
+    [Fact]
+    public void MeaningFailures_ExcludeTimedOutJudgeResults()
+    {
+        var report = Report(Scored(4, 4), JudgeTimedOut());
+
+        Assert.Empty(report.MeaningFailures);
+    }
+
+    [Fact]
+    public void Timeouts_SurfaceTimedOutResultsSeparately()
+    {
+        var report = Report(Scored(4, 4), JudgeTimedOut());
+
+        var timedOut = Assert.Single(report.Timeouts);
+        Assert.Equal("s-timeout", timedOut.ScenarioId);
+    }
+}

--- a/lucia.EvalHarness.Tests/PersonalityEvalRunnerTests.cs
+++ b/lucia.EvalHarness.Tests/PersonalityEvalRunnerTests.cs
@@ -1,0 +1,62 @@
+using lucia.EvalHarness.Personality;
+using lucia.EvalHarness.Tests.TestDoubles;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Verifies the model-under-test site deadline behavior in
+/// <see cref="PersonalityEvalRunner"/>: a model-call timeout is recorded as a distinct
+/// <see cref="PersonalityScenarioResult.TimedOut"/> result, and caller cancellation propagates.
+/// </summary>
+public sealed class PersonalityEvalRunnerTests
+{
+    private static PersonalityEvalScenario SampleScenario() => new()
+    {
+        Id = "scenario-1",
+        Category = "test",
+        Description = "sample",
+        SkillId = "skill",
+        Action = "action",
+        AgentResponse = "The light is on.",
+        PersonalityPrompt = "Be a pirate.",
+        Expectations = new PersonalityEvalExpectations()
+    };
+
+    private static PersonalityProfile SampleProfile() => new()
+    {
+        Id = "pirate",
+        Name = "Pirate",
+        Instructions = "Talk like a pirate."
+    };
+
+    [Fact]
+    public async Task RunAsync_ModelCallTimesOut_RecordsDistinctTimeout()
+    {
+        var modelClient = ScriptedChatClient.Throwing(_ => new TimeoutException("model deadline exceeded"));
+        var judgeClient = ScriptedChatClient.Returning("{}"); // never reached — model fails first
+        var runner = new PersonalityEvalRunner(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(120));
+
+        var report = await runner.RunAsync(
+            modelClient, "model-under-test", judgeClient, "judge-model",
+            [SampleScenario()], [SampleProfile()]);
+
+        var result = Assert.Single(report.Results);
+        Assert.True(result.TimedOut);
+        Assert.Equal(0, result.Score);
+        Assert.Contains("timed out", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task RunAsync_CallerCancels_Propagates()
+    {
+        var modelClient = ScriptedChatClient.Throwing(token => new OperationCanceledException(token));
+        var judgeClient = ScriptedChatClient.Returning("{}");
+        var runner = new PersonalityEvalRunner(TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(120));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => runner.RunAsync(
+            modelClient, "model-under-test", judgeClient, "judge-model",
+            [SampleScenario()], [SampleProfile()], ct: cts.Token));
+    }
+}

--- a/lucia.EvalHarness.Tests/PersonalityJudgeTests.cs
+++ b/lucia.EvalHarness.Tests/PersonalityJudgeTests.cs
@@ -1,0 +1,59 @@
+using lucia.EvalHarness.Personality;
+using lucia.EvalHarness.Tests.TestDoubles;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Verifies the judge-site deadline behavior: a deadline timeout is recorded as a
+/// distinct <see cref="JudgeResult.TimedOut"/> result (not a silent zero score),
+/// while caller cancellation propagates rather than being swallowed.
+/// </summary>
+public sealed class PersonalityJudgeTests
+{
+    private static ConversationTrace SampleTrace() => new()
+    {
+        SystemPrompt = "Be a pirate.",
+        UserMessage = "Rephrase: The light is on.",
+        AssistantResponse = "Arr, the light be lit!",
+        OriginalResponse = "The light is on."
+    };
+
+    [Fact]
+    public async Task EvaluateAsync_ValidJudgeResponse_ParsesScores()
+    {
+        var client = ScriptedChatClient.Returning(
+            """{"personalityScore":4,"personalityReason":"strong","meaningScore":5,"meaningReason":"preserved"}""");
+        var judge = new PersonalityJudge(client, TimeSpan.FromSeconds(120));
+
+        var result = await judge.EvaluateAsync(SampleTrace(), "scenario-1");
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(4, result.PersonalityScore);
+        Assert.Equal(5, result.MeaningScore);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_JudgeCallTimesOut_RecordsDistinctTimeout()
+    {
+        var client = ScriptedChatClient.Throwing(_ => new TimeoutException("judge deadline exceeded"));
+        var judge = new PersonalityJudge(client, TimeSpan.FromSeconds(120));
+
+        var result = await judge.EvaluateAsync(SampleTrace(), "scenario-1");
+
+        Assert.True(result.TimedOut);
+        Assert.Equal(0, result.PersonalityScore);
+        Assert.Contains("timed out", result.PersonalityReason);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CallerCancels_Propagates()
+    {
+        var client = ScriptedChatClient.Throwing(token => new OperationCanceledException(token));
+        var judge = new PersonalityJudge(client, TimeSpan.FromSeconds(120));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => judge.EvaluateAsync(SampleTrace(), "scenario-1", cts.Token));
+    }
+}

--- a/lucia.EvalHarness.Tests/TestDoubles/ScriptedChatClient.cs
+++ b/lucia.EvalHarness.Tests/TestDoubles/ScriptedChatClient.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.AI;
+
+namespace lucia.EvalHarness.Tests.TestDoubles;
+
+/// <summary>
+/// Configurable test <see cref="IChatClient"/> that either returns a scripted response
+/// or throws a supplied exception. Used to exercise deadline / timeout classification
+/// and result recording without a live model backend.
+/// </summary>
+internal sealed class ScriptedChatClient : IChatClient
+{
+    private readonly string? _responseText;
+    private readonly Func<CancellationToken, Exception>? _throw;
+
+    private ScriptedChatClient(string? responseText, Func<CancellationToken, Exception>? @throw)
+    {
+        _responseText = responseText;
+        _throw = @throw;
+    }
+
+    public static ScriptedChatClient Returning(string responseText) => new(responseText, null);
+
+    public static ScriptedChatClient Throwing(Func<CancellationToken, Exception> factory) => new(null, factory);
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_throw is not null)
+            throw _throw(cancellationToken);
+
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, _responseText ?? string.Empty)));
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public object? GetService(Type serviceType, object? key = null) => null;
+
+    public void Dispose() { }
+}

--- a/lucia.EvalHarness.Tests/TimedOutReportProjectionTests.cs
+++ b/lucia.EvalHarness.Tests/TimedOutReportProjectionTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using lucia.EvalHarness.Evaluation;
+using lucia.EvalHarness.Infrastructure;
+using lucia.EvalHarness.Reports;
+using lucia.EvalHarness.Tui;
+
+namespace lucia.EvalHarness.Tests;
+
+/// <summary>
+/// Verifies that a test case's <see cref="TestCaseResult.TimedOut"/> flag is carried
+/// through every persisted report projection so exported results can distinguish a
+/// deadline from an ordinary zero-score failure.
+/// </summary>
+public sealed class TimedOutReportProjectionTests
+{
+    private static EvalRunResult BuildResultWithTimeout()
+    {
+        var perf = ModelPerformanceSummary.FromSnapshots("model", []);
+        var timedOutCase = new TestCaseResult
+        {
+            TestCaseId = "tc-timeout",
+            Passed = false,
+            Score = 0,
+            Latency = TimeSpan.Zero,
+            TimedOut = true,
+            FailureReason = "Model call timed out"
+        };
+
+        return new EvalRunResult
+        {
+            RunId = "run-1",
+            StartedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            AgentResults =
+            [
+                new AgentEvalResult
+                {
+                    AgentName = "agent",
+                    ModelResults =
+                    [
+                        new ModelEvalResult
+                        {
+                            ModelName = "model",
+                            AgentName = "agent",
+                            ToolSelectionScore = 0,
+                            ToolSuccessScore = 0,
+                            ToolEfficiencyScore = 0,
+                            TaskCompletionScore = 0,
+                            OverallScore = 0,
+                            TestCaseCount = 1,
+                            PassedCount = 0,
+                            Performance = perf,
+                            TestCaseResults = [timedOutCase]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    [Fact]
+    public void HtmlReportData_CarriesTimedOut()
+    {
+        var data = HtmlReportData.FromEvalResult(BuildResultWithTimeout(), new GpuInfo("cpu"));
+
+        var tc = data.Agents[0].Models[0].TestCases![0];
+        Assert.True(tc.TimedOut);
+    }
+
+    [Fact]
+    public void ReportExporter_JsonCarriesTimedOut()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, $"report-test-{Guid.NewGuid():N}");
+        try
+        {
+            var files = ReportExporter.Export(BuildResultWithTimeout(), new GpuInfo("cpu"), dir);
+            var jsonPath = files.Single(f => f.EndsWith(".json"));
+            using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
+
+            var testCase = doc.RootElement
+                .GetProperty("agents")[0]
+                .GetProperty("models")[0]
+                .GetProperty("testCases")[0];
+            Assert.True(testCase.GetProperty("timedOut").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TraceExporter_CarriesTimedOut()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, $"trace-test-{Guid.NewGuid():N}");
+        try
+        {
+            var files = TraceExporter.Export(BuildResultWithTimeout(), dir);
+            using var doc = JsonDocument.Parse(File.ReadAllText(files.Single()));
+
+            var testCase = doc.RootElement.GetProperty("test_cases")[0];
+            Assert.True(testCase.GetProperty("timed_out").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/lucia.EvalHarness.Tests/lucia.EvalHarness.Tests.csproj
+++ b/lucia.EvalHarness.Tests/lucia.EvalHarness.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/lucia.EvalHarness/Configuration/HarnessConfiguration.cs
+++ b/lucia.EvalHarness/Configuration/HarnessConfiguration.cs
@@ -36,6 +36,39 @@ public sealed class HarnessConfiguration
     public Dictionary<string, ModelParameterProfile> ParameterProfiles { get; set; } = [];
 
     /// <summary>
+    /// Per-call deadline (seconds) for a single model-under-test / agent LLM invocation.
+    /// Must be positive; a non-positive value is a configuration error, not a silent opt-out.
+    /// </summary>
+    public int AgentTimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Per-call deadline (seconds) for a single judge / LLM-metric invocation.
+    /// Must be positive; a non-positive value is a configuration error, not a silent opt-out.
+    /// </summary>
+    public int JudgeTimeoutSeconds { get; set; } = 120;
+
+    /// <summary>Resolved per-call deadline for agent / model-under-test LLM calls.</summary>
+    public TimeSpan AgentTimeout => TimeSpan.FromSeconds(AgentTimeoutSeconds);
+
+    /// <summary>Resolved per-call deadline for judge / LLM-metric calls.</summary>
+    public TimeSpan JudgeTimeout => TimeSpan.FromSeconds(JudgeTimeoutSeconds);
+
+    /// <summary>
+    /// Validates configuration invariants. Throws when a required positive value is
+    /// zero or negative so misconfiguration fails fast instead of silently disabling deadlines.
+    /// </summary>
+    public void Validate()
+    {
+        if (AgentTimeoutSeconds <= 0)
+            throw new InvalidOperationException(
+                $"Harness:AgentTimeoutSeconds must be positive, but was {AgentTimeoutSeconds}.");
+
+        if (JudgeTimeoutSeconds <= 0)
+            throw new InvalidOperationException(
+                $"Harness:JudgeTimeoutSeconds must be positive, but was {JudgeTimeoutSeconds}.");
+    }
+
+    /// <summary>
     /// Returns the resolved list of backends. If <see cref="Backends"/> is empty,
     /// falls back to a single Ollama backend from <see cref="Ollama"/> settings.
     /// </summary>

--- a/lucia.EvalHarness/Evaluation/EvalRunner.cs
+++ b/lucia.EvalHarness/Evaluation/EvalRunner.cs
@@ -4,6 +4,7 @@ using AgentEval.Metrics.Agentic;
 using AgentEval.Models;
 using lucia.Agents.Abstractions;
 using lucia.EvalHarness.Configuration;
+using lucia.EvalHarness.Infrastructure;
 using lucia.EvalHarness.Providers;
 using lucia.HomeAssistant.Services;
 using Microsoft.Extensions.AI;
@@ -65,6 +66,12 @@ public sealed class TestCaseResult
     public string? FailureReason { get; init; }
 
     /// <summary>
+    /// True when this test case failed because an LLM call exceeded its configured
+    /// deadline. Distinguishes a genuine timeout from an ordinary zero-score failure.
+    /// </summary>
+    public bool TimedOut { get; init; }
+
+    /// <summary>
     /// The agent's full text response for this test case.
     /// </summary>
     public string? AgentOutput { get; init; }
@@ -111,14 +118,17 @@ public sealed class EvalRunner
 {
     private readonly HarnessConfiguration _config;
     private readonly IChatClient _judgeChatClient;
+    private readonly TimeProvider _timeProvider;
     private readonly PerformanceCollector _perfCollector = new();
 
     public EvalRunner(
         HarnessConfiguration config,
-        IChatClient judgeChatClient)
+        IChatClient judgeChatClient,
+        TimeProvider? timeProvider = null)
     {
         _config = config;
         _judgeChatClient = judgeChatClient;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -168,7 +178,11 @@ public sealed class EvalRunner
             try
             {
                 var (evalResult, perf) = await _perfCollector.MeasureAsync(async () =>
-                    await harness.RunEvaluationAsync(evaluableAgent, tc, options, ct), ct);
+                    await LlmDeadline.RunAsync(
+                        token => harness.RunEvaluationAsync(evaluableAgent, tc, options, token),
+                        _config.AgentTimeout, _timeProvider, ct,
+                        $"Agent '{agentInstance.AgentName}' on model '{modelName}' exceeded the {_config.AgentTimeoutSeconds}s deadline for test case '{tc.Name ?? $"test_{i}"}'."),
+                    ct);
 
                 perfSnapshots.Add(perf);
 
@@ -186,7 +200,13 @@ public sealed class EvalRunner
 
                 foreach (var metric in metrics)
                 {
-                    var metricResult = await metric.EvaluateAsync(context, ct);
+                    // The LLM-as-judge metric gets the judge deadline; code metrics are local/fast.
+                    var metricResult = metric.Name == "llm_task_completion"
+                        ? await LlmDeadline.RunAsync(
+                            token => metric.EvaluateAsync(context, token),
+                            _config.JudgeTimeout, _timeProvider, ct,
+                            $"Judge metric 'llm_task_completion' exceeded the {_config.JudgeTimeoutSeconds}s deadline for test case '{tc.Name ?? $"test_{i}"}'.")
+                        : await metric.EvaluateAsync(context, ct);
                     switch (metric.Name)
                     {
                         case "code_tool_selection":
@@ -219,6 +239,25 @@ public sealed class EvalRunner
                     AgentOutput = evalResult.ActualOutput,
                     ToolCalls = CaptureToolCalls(evalResult.ToolUsage),
                     ConversationHistory = agentInstance.Tracer?.Turns.ToList()
+                });
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Caller-requested cancellation must abort the whole run, never be
+                // recorded as a per-test-case failure.
+                throw;
+            }
+            catch (TimeoutException tex)
+            {
+                testCaseResults.Add(new TestCaseResult
+                {
+                    TestCaseId = tc.Name ?? $"test_{i}",
+                    Passed = false,
+                    Score = 0,
+                    Latency = TimeSpan.Zero,
+                    TimedOut = true,
+                    FailureReason = tex.Message,
+                    Input = tc.Input
                 });
             }
             catch (Exception ex)
@@ -406,7 +445,11 @@ public sealed class EvalRunner
 
                 // Run the agent
                 var (evalResult, perf) = await _perfCollector.MeasureAsync(async () =>
-                    await harness.RunEvaluationAsync(evaluableAgent, testCase, options, ct), ct);
+                    await LlmDeadline.RunAsync(
+                        token => harness.RunEvaluationAsync(evaluableAgent, testCase, options, token),
+                        _config.AgentTimeout, _timeProvider, ct,
+                        $"Agent '{agentInstance.AgentName}' on model '{modelName}' exceeded the {_config.AgentTimeoutSeconds}s deadline for scenario '{scenario.Id}'."),
+                    ct);
 
                 perfSnapshots.Add(perf);
 
@@ -428,6 +471,23 @@ public sealed class EvalRunner
                     ToolCalls = CaptureToolCalls(evalResult.ToolUsage),
                     ConversationHistory = conversation,
                     FailureReason = validation.Passed ? null : validation.Summary
+                });
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (TimeoutException tex)
+            {
+                testCaseResults.Add(new TestCaseResult
+                {
+                    TestCaseId = scenario.Id,
+                    Passed = false,
+                    Score = 0,
+                    Latency = TimeSpan.Zero,
+                    TimedOut = true,
+                    FailureReason = tex.Message,
+                    Input = scenario.UserPrompt
                 });
             }
             catch (Exception ex)

--- a/lucia.EvalHarness/Infrastructure/LlmDeadline.cs
+++ b/lucia.EvalHarness/Infrastructure/LlmDeadline.cs
@@ -1,0 +1,39 @@
+namespace lucia.EvalHarness.Infrastructure;
+
+/// <summary>
+/// Runs an async LLM operation under an internal timeout deadline that is kept
+/// distinct from caller cancellation. If the deadline fires first, a
+/// <see cref="TimeoutException"/> is thrown; if the caller cancels, the original
+/// <see cref="OperationCanceledException"/> propagates unchanged. A non-positive
+/// timeout disables the internal deadline and simply honors the caller token.
+/// </summary>
+internal static class LlmDeadline
+{
+    public static async Task<TResult> RunAsync<TResult>(
+        Func<CancellationToken, Task<TResult>> operation,
+        TimeSpan timeout,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken,
+        string timeoutMessage)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            return await operation(cancellationToken).ConfigureAwait(false);
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout, timeProvider);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            return await operation(linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(timeoutMessage);
+        }
+    }
+}

--- a/lucia.EvalHarness/Optimization/PromptOptimizer.cs
+++ b/lucia.EvalHarness/Optimization/PromptOptimizer.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using lucia.Agents.Abstractions;
 using lucia.EvalHarness.Evaluation;
+using lucia.EvalHarness.Infrastructure;
 using Microsoft.Extensions.AI;
 
 namespace lucia.EvalHarness.Optimization;
@@ -12,10 +13,14 @@ namespace lucia.EvalHarness.Optimization;
 public sealed class PromptOptimizer
 {
     private readonly IChatClient _judgeChatClient;
+    private readonly TimeSpan _judgeTimeout;
+    private readonly TimeProvider _timeProvider;
 
-    public PromptOptimizer(IChatClient judgeChatClient)
+    public PromptOptimizer(IChatClient judgeChatClient, TimeSpan judgeTimeout, TimeProvider? timeProvider = null)
     {
         _judgeChatClient = judgeChatClient;
+        _judgeTimeout = judgeTimeout;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -46,7 +51,10 @@ public sealed class PromptOptimizer
             ResponseFormat = ChatResponseFormat.Json
         };
 
-        var response = await _judgeChatClient.GetResponseAsync(messages, options, ct);
+        var response = await LlmDeadline.RunAsync(
+            token => _judgeChatClient.GetResponseAsync(messages, options, token),
+            _judgeTimeout, _timeProvider, ct,
+            $"Prompt optimizer judge call exceeded the {_judgeTimeout.TotalSeconds:0}s deadline for agent '{agentName}' on model '{targetModel}'.");
         var responseText = response.Text ?? "";
 
         return ParseResponse(

--- a/lucia.EvalHarness/Personality/JudgeResult.cs
+++ b/lucia.EvalHarness/Personality/JudgeResult.cs
@@ -24,4 +24,11 @@ public sealed class JudgeResult
     /// </summary>
     [JsonIgnore]
     public double CombinedScore => (PersonalityScore + MeaningScore) / 2.0;
+
+    /// <summary>
+    /// True when the judge call exceeded its configured deadline. Distinguishes a
+    /// timeout from a genuine zero-score judgement so reports don't conflate the two.
+    /// </summary>
+    [JsonIgnore]
+    public bool TimedOut { get; set; }
 }

--- a/lucia.EvalHarness/Personality/PersonalityEvalDisplay.cs
+++ b/lucia.EvalHarness/Personality/PersonalityEvalDisplay.cs
@@ -85,6 +85,7 @@ public static class PersonalityEvalDisplay
             RenderCategorySummary(report);
             RenderDetailedResults(report);
             RenderMeaningFailures(report);
+            RenderTimeouts(report);
         }
 
         if (reports.Count > 1)
@@ -110,7 +111,7 @@ public static class PersonalityEvalDisplay
 
         foreach (var group in profileGroups)
         {
-            var scored = group.Where(r => r.JudgeResult is not null).ToList();
+            var scored = group.Where(r => r.JudgeResult is { TimedOut: false }).ToList();
             var personalityAvg = scored.Count > 0
                 ? scored.Average(r => r.JudgeResult!.PersonalityScore)
                 : 0.0;
@@ -161,7 +162,7 @@ public static class PersonalityEvalDisplay
 
         foreach (var category in categories)
         {
-            var scored = category.Where(r => r.JudgeResult is not null).ToList();
+            var scored = category.Where(r => r.JudgeResult is { TimedOut: false }).ToList();
             var pAvg = scored.Count > 0 ? scored.Average(r => r.JudgeResult!.PersonalityScore) : 0.0;
             var mAvg = scored.Count > 0 ? scored.Average(r => r.JudgeResult!.MeaningScore) : 0.0;
             var combined = scored.Count > 0 ? scored.Average(r => r.JudgeResult!.CombinedScore) : 0.0;
@@ -254,6 +255,30 @@ public static class PersonalityEvalDisplay
                 AnsiConsole.MarkupLine($"     [dim]Original:  {Markup.Escape(Truncate(result.Trace.OriginalResponse, 120))}[/]");
                 AnsiConsole.MarkupLine($"     [dim]Rewritten: {Markup.Escape(Truncate(result.LlmResponse, 120))}[/]");
             }
+        }
+    }
+
+    private static void RenderTimeouts(PersonalityEvalReport report)
+    {
+        var timeouts = report.Timeouts;
+        if (timeouts.Count == 0)
+            return;
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(new Rule("[yellow bold]\u23f1 Timeouts (excluded from scores)[/]").LeftJustified());
+        AnsiConsole.MarkupLine("[yellow]These scenarios exceeded their deadline \u2014 they are not scored as failures.[/]");
+
+        foreach (var result in timeouts)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine(
+                $"  [yellow bold]\u23f1[/] [bold]{Markup.Escape(result.ScenarioId)}[/] \u00d7 " +
+                $"[yellow]{Markup.Escape(result.ProfileName)}[/] " +
+                $"[dim]({result.DurationMs}ms)[/]");
+
+            var reason = result.ErrorMessage ?? result.JudgeResult?.MeaningReason;
+            if (reason is not null)
+                AnsiConsole.MarkupLine($"     [dim]{Markup.Escape(reason)}[/]");
         }
     }
 

--- a/lucia.EvalHarness/Personality/PersonalityEvalDisplay.cs
+++ b/lucia.EvalHarness/Personality/PersonalityEvalDisplay.cs
@@ -21,9 +21,12 @@ public static class PersonalityEvalDisplay
         string judgeModelName,
         IReadOnlyList<PersonalityEvalScenario> scenarios,
         IReadOnlyList<PersonalityProfile> selectedProfiles,
+        TimeSpan agentTimeout,
+        TimeSpan judgeTimeout,
+        TimeProvider? timeProvider = null,
         CancellationToken ct = default)
     {
-        var runner = new PersonalityEvalRunner();
+        var runner = new PersonalityEvalRunner(agentTimeout, judgeTimeout, timeProvider);
         var reports = new List<PersonalityEvalReport>();
         var totalCombinations = PersonalityEvalRunner.CountCombinations(scenarios, selectedProfiles);
 

--- a/lucia.EvalHarness/Personality/PersonalityEvalReport.cs
+++ b/lucia.EvalHarness/Personality/PersonalityEvalReport.cs
@@ -15,10 +15,11 @@ public sealed class PersonalityEvalReport
     public int TotalCombinations => Results.Count;
 
     /// <summary>
-    /// Average combined score across all results (1–5 scale).
+    /// Average combined score across all successfully judged results (1–5 scale).
+    /// Timed-out judge results are excluded so a judge outage doesn't lower scores.
     /// </summary>
     public double AverageCombinedScore =>
-        Results.Where(r => r.JudgeResult is not null).Select(r => r.JudgeResult!.CombinedScore).DefaultIfEmpty(0).Average();
+        Results.Where(r => r.JudgeResult is { TimedOut: false }).Select(r => r.JudgeResult!.CombinedScore).DefaultIfEmpty(0).Average();
 
     public IReadOnlyList<string> ScenarioIds =>
         Results.Select(r => r.ScenarioId).Distinct().ToList();
@@ -27,20 +28,31 @@ public sealed class PersonalityEvalReport
         Results.Select(r => r.ProfileId).Distinct().ToList();
 
     /// <summary>
-    /// Average personality adherence score across all results (0-5).
+    /// Average personality adherence score across all successfully judged results (0-5).
+    /// Timed-out judge results are excluded.
     /// </summary>
     public double AveragePersonalityScore =>
-        Results.Where(r => r.JudgeResult is not null).Select(r => r.JudgeResult!.PersonalityScore).DefaultIfEmpty(0).Average();
+        Results.Where(r => r.JudgeResult is { TimedOut: false }).Select(r => r.JudgeResult!.PersonalityScore).DefaultIfEmpty(0).Average();
 
     /// <summary>
-    /// Average meaning preservation score across all results (0-5).
+    /// Average meaning preservation score across all successfully judged results (0-5).
+    /// Timed-out judge results are excluded.
     /// </summary>
     public double AverageMeaningScore =>
-        Results.Where(r => r.JudgeResult is not null).Select(r => r.JudgeResult!.MeaningScore).DefaultIfEmpty(0).Average();
+        Results.Where(r => r.JudgeResult is { TimedOut: false }).Select(r => r.JudgeResult!.MeaningScore).DefaultIfEmpty(0).Average();
 
     /// <summary>
     /// Results where meaning score is below 3 — the dangerous failures.
+    /// Timed-out judge results are excluded so a judge outage isn't reported as meaning loss.
     /// </summary>
     public IReadOnlyList<PersonalityScenarioResult> MeaningFailures =>
-        Results.Where(r => r.JudgeResult is not null && r.JudgeResult.MeaningScore < 3).ToList();
+        Results.Where(r => r.JudgeResult is { TimedOut: false } && r.JudgeResult.MeaningScore < 3).ToList();
+
+    /// <summary>
+    /// Results that failed because the model-under-test or judge call exceeded its
+    /// deadline. Surfaced separately from scored failures so timeouts aren't conflated
+    /// with genuine zero-score judgements.
+    /// </summary>
+    public IReadOnlyList<PersonalityScenarioResult> Timeouts =>
+        Results.Where(r => r.TimedOut).ToList();
 }

--- a/lucia.EvalHarness/Personality/PersonalityEvalReport.cs
+++ b/lucia.EvalHarness/Personality/PersonalityEvalReport.cs
@@ -15,7 +15,7 @@ public sealed class PersonalityEvalReport
     public int TotalCombinations => Results.Count;
 
     /// <summary>
-    /// Average combined score across all successfully judged results (1–5 scale).
+    /// Average combined score across all successfully judged results (1-5 scale).
     /// Timed-out judge results are excluded so a judge outage doesn't lower scores.
     /// </summary>
     public double AverageCombinedScore =>

--- a/lucia.EvalHarness/Personality/PersonalityEvalRunner.cs
+++ b/lucia.EvalHarness/Personality/PersonalityEvalRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using lucia.EvalHarness.Infrastructure;
 using Microsoft.Extensions.AI;
 
 namespace lucia.EvalHarness.Personality;
@@ -10,6 +11,17 @@ namespace lucia.EvalHarness.Personality;
 /// </summary>
 public sealed class PersonalityEvalRunner
 {
+    private readonly TimeSpan _agentTimeout;
+    private readonly TimeSpan _judgeTimeout;
+    private readonly TimeProvider _timeProvider;
+
+    public PersonalityEvalRunner(TimeSpan agentTimeout, TimeSpan judgeTimeout, TimeProvider? timeProvider = null)
+    {
+        _agentTimeout = agentTimeout;
+        _judgeTimeout = judgeTimeout;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
     private static readonly string PersonalityRewritePrompt =
         "Rephrase the following smart home assistant response in your voice. " +
         "Keep the SAME meaning \u2014 if it's an error, keep it as an error. If it's a question, keep it as a question. " +
@@ -60,7 +72,7 @@ public sealed class PersonalityEvalRunner
         var startedAt = DateTimeOffset.UtcNow;
         var results = new List<PersonalityScenarioResult>();
         var traceDir = Path.Combine("personality-eval-traces", $"{modelName}_{startedAt:yyyyMMdd_HHmmss}");
-        var judge = new PersonalityJudge(judgeChatClient, traceDir);
+        var judge = new PersonalityJudge(judgeChatClient, _judgeTimeout, traceDir, _timeProvider);
 
         foreach (var scenario in scenarios)
         {
@@ -113,7 +125,7 @@ public sealed class PersonalityEvalRunner
             .ToList();
     }
 
-    private static async Task<PersonalityScenarioResult> EvaluateSingleAsync(
+    private async Task<PersonalityScenarioResult> EvaluateSingleAsync(
         IChatClient chatClient,
         string modelName,
         PersonalityJudge judge,
@@ -134,8 +146,29 @@ public sealed class PersonalityEvalRunner
                 new(ChatRole.User, userMessage)
             };
 
-            var response = await chatClient.GetResponseAsync(messages, cancellationToken: ct);
+            var response = await LlmDeadline.RunAsync(
+                token => chatClient.GetResponseAsync(messages, cancellationToken: token),
+                _agentTimeout, _timeProvider, ct,
+                $"Model '{modelName}' exceeded the {_agentTimeout.TotalSeconds:0}s deadline for scenario '{scenario.Id}' × profile '{profile.Id}'.");
             llmResponse = response.Text ?? string.Empty;
+        }
+        catch (TimeoutException tex)
+        {
+            sw.Stop();
+            return new PersonalityScenarioResult
+            {
+                ScenarioId = scenario.Id,
+                ScenarioDescription = scenario.Description,
+                Category = scenario.Category,
+                ProfileId = profile.Id,
+                ProfileName = profile.Name,
+                ModelName = modelName,
+                Score = 0,
+                LlmResponse = string.Empty,
+                DurationMs = sw.ElapsedMilliseconds,
+                TimedOut = true,
+                ErrorMessage = $"Model call timed out: {tex.Message}"
+            };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -179,6 +212,7 @@ public sealed class PersonalityEvalRunner
             Score = judgeResult.CombinedScore,
             LlmResponse = llmResponse,
             DurationMs = sw.ElapsedMilliseconds,
+            TimedOut = judgeResult.TimedOut,
             JudgeResult = judgeResult,
             Trace = trace
         };

--- a/lucia.EvalHarness/Personality/PersonalityJudge.cs
+++ b/lucia.EvalHarness/Personality/PersonalityJudge.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using lucia.EvalHarness.Infrastructure;
 using Microsoft.Extensions.AI;
 
 namespace lucia.EvalHarness.Personality;
@@ -34,11 +35,15 @@ public sealed class PersonalityJudge
         """;
 
     private readonly IChatClient _judgeChatClient;
+    private readonly TimeSpan _judgeTimeout;
+    private readonly TimeProvider _timeProvider;
     private readonly string? _traceDir;
 
-    public PersonalityJudge(IChatClient judgeChatClient, string? traceOutputDir = null)
+    public PersonalityJudge(IChatClient judgeChatClient, TimeSpan judgeTimeout, string? traceOutputDir = null, TimeProvider? timeProvider = null)
     {
         _judgeChatClient = judgeChatClient;
+        _judgeTimeout = judgeTimeout;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _traceDir = traceOutputDir;
         if (_traceDir is not null)
             Directory.CreateDirectory(_traceDir);
@@ -61,11 +66,26 @@ public sealed class PersonalityJudge
 
         try
         {
-            var response = await _judgeChatClient.GetResponseAsync(messages, cancellationToken: ct);
+            var response = await LlmDeadline.RunAsync(
+                token => _judgeChatClient.GetResponseAsync(messages, cancellationToken: token),
+                _judgeTimeout, _timeProvider, ct,
+                $"Judge call exceeded the {_judgeTimeout.TotalSeconds:0}s deadline for scenario '{scenarioId ?? "unknown"}'.");
             var text = response.Text ?? string.Empty;
             var result = ParseJudgeResponse(text);
             DumpTrace(scenarioId, formattedTrace, text, null);
             return result;
+        }
+        catch (TimeoutException tex)
+        {
+            DumpTrace(scenarioId, formattedTrace, null, tex);
+            return new JudgeResult
+            {
+                PersonalityScore = 0,
+                PersonalityReason = $"Judge call timed out: {tex.Message}",
+                MeaningScore = 0,
+                MeaningReason = $"Judge call timed out: {tex.Message}",
+                TimedOut = true
+            };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/lucia.EvalHarness/Personality/PersonalityScenarioResult.cs
+++ b/lucia.EvalHarness/Personality/PersonalityScenarioResult.cs
@@ -34,4 +34,10 @@ public sealed class PersonalityScenarioResult
     /// Error message when the model-under-test or judge call fails.
     /// </summary>
     public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// True when this result failed because the model-under-test or judge call
+    /// exceeded its configured deadline, as opposed to an ordinary failure.
+    /// </summary>
+    public bool TimedOut { get; init; }
 }

--- a/lucia.EvalHarness/Program.cs
+++ b/lucia.EvalHarness/Program.cs
@@ -23,6 +23,7 @@ var configBuilder = new ConfigurationBuilder()
 var configRoot = configBuilder.Build();
 var config = new HarnessConfiguration();
 configRoot.GetSection("Harness").Bind(config);
+config.Validate();
 
 // ─── Initialize Services ─────────────────────────────────────────────
 using var httpClient = new HttpClient();
@@ -194,7 +195,9 @@ if (evalType == EvalTypeSelector.PersonalityEval)
         judgeChatClient,
         judgeModelName,
         scenarios,
-        personalityProfiles);
+        personalityProfiles,
+        config.AgentTimeout,
+        config.JudgeTimeout);
 
     lucia.EvalHarness.Personality.PersonalityEvalDisplay.RenderReport(reports);
 
@@ -343,7 +346,7 @@ if (judgeChatClient is not NoOpChatClient &&
     AnsiConsole.Write(new Rule("[bold]Prompt Optimization[/]").LeftJustified());
     AnsiConsole.WriteLine();
 
-    var optimizer = new lucia.EvalHarness.Optimization.PromptOptimizer(judgeChatClient);
+    var optimizer = new lucia.EvalHarness.Optimization.PromptOptimizer(judgeChatClient, config.JudgeTimeout);
     var optimizationResults = new List<lucia.EvalHarness.Optimization.PromptOptimizationResult>();
 
     // Find the best-performing model's results as baseline

--- a/lucia.EvalHarness/Reports/HtmlReportData.cs
+++ b/lucia.EvalHarness/Reports/HtmlReportData.cs
@@ -143,6 +143,7 @@ public sealed class HtmlReportData
                     {
                         Id = tc.TestCaseId,
                         Passed = tc.Passed,
+                        TimedOut = tc.TimedOut,
                         Score = tc.Score,
                         LatencyMs = tc.Latency.TotalMilliseconds,
                         FailureReason = tc.FailureReason,

--- a/lucia.EvalHarness/Reports/HtmlTestCaseData.cs
+++ b/lucia.EvalHarness/Reports/HtmlTestCaseData.cs
@@ -10,6 +10,9 @@ public sealed class HtmlTestCaseData
     [JsonPropertyName("passed")]
     public bool Passed { get; init; }
 
+    [JsonPropertyName("timedOut")]
+    public bool TimedOut { get; init; }
+
     [JsonPropertyName("score")]
     public double Score { get; init; }
 

--- a/lucia.EvalHarness/Tui/ReportExporter.cs
+++ b/lucia.EvalHarness/Tui/ReportExporter.cs
@@ -291,6 +291,7 @@ public static class ReportExporter
                 {
                     id = tc.TestCaseId,
                     passed = tc.Passed,
+                    timedOut = tc.TimedOut,
                     score = tc.Score,
                     latencyMs = tc.Latency.TotalMilliseconds,
                     failureReason = tc.FailureReason

--- a/lucia.EvalHarness/Tui/TraceExporter.cs
+++ b/lucia.EvalHarness/Tui/TraceExporter.cs
@@ -54,6 +54,7 @@ public static class TraceExporter
                     {
                         Id = tc.TestCaseId,
                         Passed = tc.Passed,
+                        TimedOut = tc.TimedOut,
                         Score = tc.Score,
                         LatencyMs = tc.Latency.TotalMilliseconds,
                         FailureReason = tc.FailureReason,
@@ -226,6 +227,9 @@ file sealed class TraceTestCase
 
     [JsonPropertyName("passed")]
     public required bool Passed { get; init; }
+
+    [JsonPropertyName("timed_out")]
+    public required bool TimedOut { get; init; }
 
     [JsonPropertyName("score")]
     public required double Score { get; init; }

--- a/lucia.HomeAssistant/Services/AsyncDeadline.cs
+++ b/lucia.HomeAssistant/Services/AsyncDeadline.cs
@@ -1,0 +1,39 @@
+namespace lucia.HomeAssistant.Services;
+
+/// <summary>
+/// Runs an async operation under an internal timeout deadline that is kept
+/// distinct from caller cancellation. If the deadline fires first, a
+/// <see cref="TimeoutException"/> is thrown; if the caller cancels, the original
+/// <see cref="OperationCanceledException"/> propagates unchanged. A non-positive
+/// timeout disables the internal deadline and simply honors the caller token.
+/// </summary>
+internal static class AsyncDeadline
+{
+    public static async Task<TResult> RunAsync<TResult>(
+        Func<CancellationToken, Task<TResult>> operation,
+        TimeSpan timeout,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken,
+        string timeoutMessage)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            return await operation(cancellationToken).ConfigureAwait(false);
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout, timeProvider);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            return await operation(linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(timeoutMessage);
+        }
+    }
+}

--- a/lucia.HomeAssistant/Services/HomeAssistantClient.cs
+++ b/lucia.HomeAssistant/Services/HomeAssistantClient.cs
@@ -19,15 +19,17 @@ public sealed class HomeAssistantClient : IHomeAssistantClient
     private readonly HttpClient _httpClient;
     private readonly ILogger<HomeAssistantClient> _logger;
     private readonly IOptionsMonitor<HomeAssistantOptions> _optionsMonitor;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>Current config snapshot — always reads latest from the options monitor.</summary>
     private HomeAssistantOptions Options => _optionsMonitor.CurrentValue;
 
-    public HomeAssistantClient(HttpClient httpClient, ILogger<HomeAssistantClient> logger, IOptionsMonitor<HomeAssistantOptions> optionsMonitor)
+    public HomeAssistantClient(HttpClient httpClient, ILogger<HomeAssistantClient> logger, IOptionsMonitor<HomeAssistantOptions> optionsMonitor, TimeProvider? timeProvider = null)
     {
         _httpClient = httpClient;
         _logger = logger;
         _optionsMonitor = optionsMonitor;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -737,54 +739,62 @@ public sealed class HomeAssistantClient : IHomeAssistantClient
 
         _logger.WebSocketConnecting(wsUri.ToString());
 
-        using var ws = new ClientWebSocket();
-        await ws.ConnectAsync(wsUri, ct);
+        // Internal deadline: the configured timeout bounds the whole connect →
+        // auth → command → read sequence, independent of the caller's token.
+        var timeout = TimeSpan.FromSeconds(Options.TimeoutSeconds);
 
+        using var ws = new ClientWebSocket();
         try
         {
-            // Step 1: Receive auth_required message
-            var authRequired = await WsReadJsonAsync(ws, ct);
-            var msgType = GetJsonStringProperty(authRequired, "type");
-            if (msgType != "auth_required")
-                throw new InvalidOperationException($"Expected 'auth_required', got '{msgType}'");
-
-            // Step 2: Send auth
-            await WsWriteJsonAsync(ws, new { type = "auth", access_token = Options.AccessToken }, ct);
-
-            // Step 3: Receive auth result
-            var authResult = await WsReadJsonAsync(ws, ct);
-            msgType = GetJsonStringProperty(authResult, "type");
-            if (msgType != "auth_ok")
+            return await AsyncDeadline.RunAsync<T?>(async token =>
             {
-                var authMsg = GetJsonStringProperty(authResult, "message");
-                throw new InvalidOperationException($"WebSocket auth failed: {authMsg}");
-            }
+                await ws.ConnectAsync(wsUri, token);
 
-            // Step 4: Send command (merge payload properties into command message)
-            _logger.WebSocketCommand(commandType);
-            var command = BuildWsCommand(1, commandType, payload);
-            await WsWriteJsonAsync(ws, command, ct);
+                // Step 1: Receive auth_required message
+                var authRequired = await WsReadJsonAsync(ws, token);
+                var msgType = GetJsonStringProperty(authRequired, "type");
+                if (msgType != "auth_required")
+                    throw new InvalidOperationException($"Expected 'auth_required', got '{msgType}'");
 
-            // Step 5: Receive command result
-            var result = await WsReadJsonAsync(ws, ct);
-            var success = result.RootElement.TryGetProperty("success", out var successProp)
-                          && successProp.GetBoolean();
+                // Step 2: Send auth
+                await WsWriteJsonAsync(ws, new { type = "auth", access_token = Options.AccessToken }, token);
 
-            if (!success)
-            {
-                var errorMsg = result.RootElement.TryGetProperty("error", out var errorProp)
-                    ? errorProp.ToString()
-                    : "Unknown WebSocket error";
-                _logger.WebSocketCommandFailed(commandType, errorMsg);
-                throw new InvalidOperationException($"WebSocket command '{commandType}' failed: {errorMsg}");
-            }
+                // Step 3: Receive auth result
+                var authResult = await WsReadJsonAsync(ws, token);
+                msgType = GetJsonStringProperty(authResult, "type");
+                if (msgType != "auth_ok")
+                {
+                    var authMsg = GetJsonStringProperty(authResult, "message");
+                    throw new InvalidOperationException($"WebSocket auth failed: {authMsg}");
+                }
 
-            if (result.RootElement.TryGetProperty("result", out var resultProp))
-            {
-                return JsonSerializer.Deserialize<T>(resultProp.GetRawText(), HomeAssistantJsonOptions.Default);
-            }
+                // Step 4: Send command (merge payload properties into command message)
+                _logger.WebSocketCommand(commandType);
+                var command = BuildWsCommand(1, commandType, payload);
+                await WsWriteJsonAsync(ws, command, token);
 
-            return default;
+                // Step 5: Receive command result
+                var result = await WsReadJsonAsync(ws, token);
+                var success = result.RootElement.TryGetProperty("success", out var successProp)
+                              && successProp.GetBoolean();
+
+                if (!success)
+                {
+                    var errorMsg = result.RootElement.TryGetProperty("error", out var errorProp)
+                        ? errorProp.ToString()
+                        : "Unknown WebSocket error";
+                    _logger.WebSocketCommandFailed(commandType, errorMsg);
+                    throw new InvalidOperationException($"WebSocket command '{commandType}' failed: {errorMsg}");
+                }
+
+                if (result.RootElement.TryGetProperty("result", out var resultProp))
+                {
+                    return JsonSerializer.Deserialize<T>(resultProp.GetRawText(), HomeAssistantJsonOptions.Default);
+                }
+
+                return default;
+            }, timeout, _timeProvider, ct,
+            $"Home Assistant WebSocket command '{commandType}' did not complete within {Options.TimeoutSeconds}s.");
         }
         finally
         {
@@ -792,7 +802,12 @@ public sealed class HomeAssistantClient : IHomeAssistantClient
             {
                 try
                 {
-                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                    // Bound close/cleanup with its own deadline so a wedged socket
+                    // can't hang the caller indefinitely during teardown.
+                    using var closeCts = timeout > TimeSpan.Zero
+                        ? new CancellationTokenSource(timeout, _timeProvider)
+                        : new CancellationTokenSource();
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", closeCts.Token);
                 }
                 catch
                 {

--- a/lucia.HomeAssistant/lucia.HomeAssistant.csproj
+++ b/lucia.HomeAssistant/lucia.HomeAssistant.csproj
@@ -8,4 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="lucia.Tests" />
+  </ItemGroup>
 </Project>

--- a/lucia.Tests/AsyncDeadlineTests.cs
+++ b/lucia.Tests/AsyncDeadlineTests.cs
@@ -1,0 +1,93 @@
+using lucia.HomeAssistant.Services;
+using Microsoft.Extensions.Time.Testing;
+
+namespace lucia.Tests;
+
+/// <summary>
+/// Deterministic tests for <see cref="AsyncDeadline"/>, which backs the internal
+/// timeout applied to Home Assistant WebSocket commands. Uses <see cref="FakeTimeProvider"/>
+/// to fire the deadline while an operation is genuinely in-flight (not a pre-cancel).
+/// </summary>
+public sealed class AsyncDeadlineTests
+{
+    [Fact]
+    public async Task RunAsync_InternalTimeoutFiresWhileInFlight_ThrowsTimeoutException()
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        var task = AsyncDeadline.RunAsync<int>(
+            BlockUntilCanceledAsync,
+            TimeSpan.FromSeconds(30),
+            timeProvider,
+            CancellationToken.None,
+            "op timed out");
+
+        // Advance past the deadline while the operation is still awaiting.
+        timeProvider.Advance(TimeSpan.FromSeconds(31));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => task);
+    }
+
+    [Fact]
+    public async Task RunAsync_CallerCancels_PropagatesOperationCanceled_NotTimeout()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var caller = new CancellationTokenSource();
+
+        var task = AsyncDeadline.RunAsync<int>(
+            BlockUntilCanceledAsync,
+            TimeSpan.FromSeconds(30),
+            timeProvider,
+            caller.Token,
+            "op timed out");
+
+        caller.Cancel();
+
+        // Caller cancellation must surface as OperationCanceledException, never TimeoutException.
+        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task RunAsync_OperationCompletesBeforeDeadline_ReturnsResult()
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        var result = await AsyncDeadline.RunAsync<int>(
+            _ => Task.FromResult(7),
+            TimeSpan.FromSeconds(30),
+            timeProvider,
+            CancellationToken.None,
+            "op timed out");
+
+        Assert.Equal(7, result);
+    }
+
+    [Fact]
+    public async Task RunAsync_NonPositiveTimeout_DisablesDeadline_HonorsCallerToken()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var caller = new CancellationTokenSource();
+        caller.Cancel();
+
+        // No internal deadline; the pre-cancelled caller token must still cancel the op.
+        await Assert.ThrowsAsync<TaskCanceledException>(() => AsyncDeadline.RunAsync<int>(
+            BlockUntilCanceledAsync,
+            TimeSpan.Zero,
+            timeProvider,
+            caller.Token,
+            "op timed out"));
+    }
+
+    /// <summary>
+    /// Deterministic stand-in for an in-flight operation: completes only when the
+    /// supplied token is canceled (by the deadline or the caller), throwing
+    /// <see cref="OperationCanceledException"/>. Uses a <see cref="TaskCompletionSource{TResult}"/>
+    /// rather than <c>Task.Delay</c> so no wall-clock time is involved.
+    /// </summary>
+    private static async Task<int> BlockUntilCanceledAsync(CancellationToken token)
+    {
+        var tcs = new TaskCompletionSource<int>();
+        await using var registration = token.Register(() => tcs.TrySetCanceled(token));
+        return await tcs.Task;
+    }
+}

--- a/lucia.Tests/Timer/TimerSkillTests.cs
+++ b/lucia.Tests/Timer/TimerSkillTests.cs
@@ -318,11 +318,43 @@ public sealed class TimerSkillTests
                 return Task.FromException(new OperationCanceledException(cts.Token));
             });
 
+        // The OCE arrived before the write committed, so the persisted status is still Pending.
+        A.CallTo(() => _taskRepository.GetByIdAsync(timerId, A<CancellationToken>._))
+            .Returns(BuildTimerDocument(timerId, ScheduledTaskStatus.Pending));
+
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => _skill.CancelTimerAsync(timerId, cts.Token));
 
         // Task must be back in the store so it still fires and the stores stay consistent.
         Assert.Equal(1, _skill.ActiveTimerCount);
+    }
+
+    [Fact]
+    public async Task CancelTimerAsync_CallerCancelled_StatusDurablyCancelled_LeavesTaskRemoved()
+    {
+        // Mongo can durably commit Cancelled and *still* surface an OperationCanceledException when
+        // the caller's token trips as the reply unwinds.  Blindly restoring the in-memory task here
+        // resurrects a ghost timer that fires despite the durable record saying it was cancelled.
+        // Reading the persisted status back reveals Cancelled, so the task must stay removed.
+        var setResult = await _skill.SetTimerAsync(300, "Ghost me", "assist_satellite.kitchen");
+        var timerId = ExtractTimerId(setResult);
+        using var cts = new CancellationTokenSource();
+
+        A.CallTo(() => _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>._))
+            .ReturnsLazily(call =>
+            {
+                cts.Cancel();
+                return Task.FromException(new OperationCanceledException(cts.Token));
+            });
+
+        A.CallTo(() => _taskRepository.GetByIdAsync(timerId, A<CancellationToken>._))
+            .Returns(BuildTimerDocument(timerId, ScheduledTaskStatus.Cancelled));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _skill.CancelTimerAsync(timerId, cts.Token));
+
+        // Durable state is Cancelled — the in-memory task must not be resurrected as a ghost.
+        Assert.Equal(0, _skill.ActiveTimerCount);
     }
 
     [Fact]
@@ -333,6 +365,20 @@ public sealed class TimerSkillTests
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => _skill.ListTimers(cts.Token));
     }
+
+    /// <summary>
+    /// Builds a minimal timer document with a given persisted status for read-back reconciliation tests.
+    /// </summary>
+    private static ScheduledTaskDocument BuildTimerDocument(string id, ScheduledTaskStatus status)
+        => new()
+        {
+            Id = id,
+            TaskId = Guid.NewGuid().ToString("N"),
+            Label = "Timer",
+            FireAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            TaskType = ScheduledTaskType.Timer,
+            Status = status
+        };
 
     /// <summary>
     /// Extracts the timer ID from a SetTimer result string like "Timer 'abc12345' set for ...".

--- a/lucia.Tests/Timer/TimerSkillTests.cs
+++ b/lucia.Tests/Timer/TimerSkillTests.cs
@@ -250,15 +250,22 @@ public sealed class TimerSkillTests
     [Fact]
     public async Task SetTimerAsync_CallerCancelled_RepositoryOce_IsNotSwallowed()
     {
+        // Cancel from inside UpsertAsync so the entry ThrowIfCancellationRequested guard is
+        // bypassed and the catch/rethrow branch in SetTimerAsync is actually exercised.
         using var cts = new CancellationTokenSource();
-        cts.Cancel();
 
         A.CallTo(() => _taskRepository.UpsertAsync(A<ScheduledTaskDocument>._, A<CancellationToken>._))
-            .ThrowsAsync(new OperationCanceledException(cts.Token));
+            .ReturnsLazily(call =>
+            {
+                cts.Cancel();
+                return Task.FromException(new OperationCanceledException(cts.Token));
+            });
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => _skill.SetTimerAsync(120, "Cancel me", "assist_satellite.kitchen", cts.Token));
 
+        A.CallTo(() => _taskRepository.UpsertAsync(A<ScheduledTaskDocument>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
         // Caller cancellation must abort — the timer is not silently created in-memory.
         Assert.Equal(0, _skill.ActiveTimerCount);
     }
@@ -291,6 +298,31 @@ public sealed class TimerSkillTests
             ScheduledTaskStatus.Cancelled,
             A<CancellationToken>.That.IsEqualTo(cts.Token)))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task CancelTimerAsync_CallerCancelled_DuringStatusUpdate_RestoresTaskToStore()
+    {
+        // If the caller's token fires while UpdateStatusAsync is in-flight, TryRemove has already
+        // removed the task from the in-memory store.  Without a restore the task disappears from
+        // memory while MongoDB still holds a Pending/Active document, and
+        // ScheduledTaskRecoveryService would resurrect it as a ghost on restart.
+        var setResult = await _skill.SetTimerAsync(300, "Restore me", "assist_satellite.kitchen");
+        var timerId = ExtractTimerId(setResult);
+        using var cts = new CancellationTokenSource();
+
+        A.CallTo(() => _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>._))
+            .ReturnsLazily(call =>
+            {
+                cts.Cancel();
+                return Task.FromException(new OperationCanceledException(cts.Token));
+            });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _skill.CancelTimerAsync(timerId, cts.Token));
+
+        // Task must be back in the store so it still fires and the stores stay consistent.
+        Assert.Equal(1, _skill.ActiveTimerCount);
     }
 
     [Fact]

--- a/lucia.Tests/Timer/TimerSkillTests.cs
+++ b/lucia.Tests/Timer/TimerSkillTests.cs
@@ -205,6 +205,89 @@ public sealed class TimerSkillTests
             .MustHaveHappenedOnceExactly();
     }
 
+    [Fact]
+    public async Task SetTimerAsync_PropagatesCallerToken_ToRepository()
+    {
+        using var cts = new CancellationTokenSource();
+
+        await _skill.SetTimerAsync(120, "Token flows", "assist_satellite.kitchen", cts.Token);
+
+        A.CallTo(() => _taskRepository.UpsertAsync(
+            A<ScheduledTaskDocument>._,
+            A<CancellationToken>.That.IsEqualTo(cts.Token)))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task SetTimerAsync_PropagatesCallerToken_ToEntityLocationService()
+    {
+        using var cts = new CancellationTokenSource();
+
+        // A bare location name (no dot) forces resolution via the entity location service.
+        await _skill.SetTimerAsync(120, "Locate me", "office", cts.Token);
+
+        A.CallTo(() => _entityLocationService.FindEntitiesByLocationAsync(
+            "office",
+            A<IReadOnlyList<string>?>._,
+            A<CancellationToken>.That.IsEqualTo(cts.Token)))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task SetTimerAsync_CallerCancelled_RepositoryOce_IsNotSwallowed()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        A.CallTo(() => _taskRepository.UpsertAsync(A<ScheduledTaskDocument>._, A<CancellationToken>._))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _skill.SetTimerAsync(120, "Cancel me", "assist_satellite.kitchen", cts.Token));
+
+        // Caller cancellation must abort — the timer is not silently created in-memory.
+        Assert.Equal(0, _skill.ActiveTimerCount);
+    }
+
+    [Fact]
+    public async Task SetTimerAsync_NonCallerOce_IsSwallowed_TimerRunsInMemory()
+    {
+        // A repository OCE that is NOT the caller's cancellation (e.g. Mongo internal timeout)
+        // must be treated as a persistence failure and fall back to the in-memory timer.
+        A.CallTo(() => _taskRepository.UpsertAsync(A<ScheduledTaskDocument>._, A<CancellationToken>._))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var result = await _skill.SetTimerAsync(120, "Fallback", "assist_satellite.kitchen", CancellationToken.None);
+
+        Assert.Contains("set for", result);
+        Assert.Equal(1, _skill.ActiveTimerCount);
+    }
+
+    [Fact]
+    public async Task CancelTimerAsync_PropagatesCallerToken_ToRepository()
+    {
+        var setResult = await _skill.SetTimerAsync(300, "Cancel me", "assist_satellite.kitchen");
+        var timerId = ExtractTimerId(setResult);
+        using var cts = new CancellationTokenSource();
+
+        await _skill.CancelTimerAsync(timerId, cts.Token);
+
+        A.CallTo(() => _taskRepository.UpdateStatusAsync(
+            timerId,
+            ScheduledTaskStatus.Cancelled,
+            A<CancellationToken>.That.IsEqualTo(cts.Token)))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task ListTimers_CallerCancelled_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => _skill.ListTimers(cts.Token));
+    }
+
     /// <summary>
     /// Extracts the timer ID from a SetTimer result string like "Timer 'abc12345' set for ...".
     /// </summary>

--- a/lucia.Tests/Timer/TimerSkillTests.cs
+++ b/lucia.Tests/Timer/TimerSkillTests.cs
@@ -266,7 +266,7 @@ public sealed class TimerSkillTests
 
         A.CallTo(() => _taskRepository.UpsertAsync(A<ScheduledTaskDocument>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
-        // Caller cancellation must abort — the timer is not silently created in-memory.
+        // Caller cancellation must abort -- the timer is not silently created in-memory.
         Assert.Equal(0, _skill.ActiveTimerCount);
     }
 
@@ -301,59 +301,37 @@ public sealed class TimerSkillTests
     }
 
     [Fact]
-    public async Task CancelTimerAsync_CallerCancelled_DuringStatusUpdate_RestoresTaskToStore()
+    public async Task CancelTimerAsync_CallerCancelled_DuringStatusUpdate_ConvergesAndLeavesTimerRemoved()
     {
-        // If the caller's token fires while UpdateStatusAsync is in-flight, TryRemove has already
-        // removed the task from the in-memory store.  Without a restore the task disappears from
-        // memory while MongoDB still holds a Pending/Active document, and
-        // ScheduledTaskRecoveryService would resurrect it as a ghost on restart.
-        var setResult = await _skill.SetTimerAsync(300, "Restore me", "assist_satellite.kitchen");
+        // Arrange: the caller's token fires inside UpdateStatusAsync. The first write may commit
+        // Cancelled after the OCE surfaces (late-commit scenario). The compensation must write
+        // the same terminal Cancelled with an uncancellable token so both the original and the
+        // compensation converge on Cancelled regardless of ordering -- no ghost timer fires.
+        var setResult = await _skill.SetTimerAsync(300, "Converge me", "assist_satellite.kitchen");
         var timerId = ExtractTimerId(setResult);
         using var cts = new CancellationTokenSource();
 
-        A.CallTo(() => _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>._))
-            .ReturnsLazily(call =>
+        A.CallTo(() => _taskRepository.UpdateStatusAsync(
+                timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>.That.Matches(ct => ct.CanBeCanceled)))
+            .ReturnsLazily(_ =>
             {
                 cts.Cancel();
                 return Task.FromException(new OperationCanceledException(cts.Token));
             });
 
-        // The OCE arrived before the write committed, so the persisted status is still Pending.
-        A.CallTo(() => _taskRepository.GetByIdAsync(timerId, A<CancellationToken>._))
-            .Returns(BuildTimerDocument(timerId, ScheduledTaskStatus.Pending));
+        A.CallTo(() => _taskRepository.UpdateStatusAsync(
+                timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>.That.Matches(ct => !ct.CanBeCanceled)))
+            .Returns(Task.CompletedTask);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => _skill.CancelTimerAsync(timerId, cts.Token));
 
-        // Task must be back in the store so it still fires and the stores stay consistent.
-        Assert.Equal(1, _skill.ActiveTimerCount);
-    }
+        // Compensation must have written terminal Cancelled with a non-cancellable token.
+        A.CallTo(() => _taskRepository.UpdateStatusAsync(
+                timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>.That.Matches(ct => !ct.CanBeCanceled)))
+            .MustHaveHappenedOnceExactly();
 
-    [Fact]
-    public async Task CancelTimerAsync_CallerCancelled_StatusDurablyCancelled_LeavesTaskRemoved()
-    {
-        // Mongo can durably commit Cancelled and *still* surface an OperationCanceledException when
-        // the caller's token trips as the reply unwinds.  Blindly restoring the in-memory task here
-        // resurrects a ghost timer that fires despite the durable record saying it was cancelled.
-        // Reading the persisted status back reveals Cancelled, so the task must stay removed.
-        var setResult = await _skill.SetTimerAsync(300, "Ghost me", "assist_satellite.kitchen");
-        var timerId = ExtractTimerId(setResult);
-        using var cts = new CancellationTokenSource();
-
-        A.CallTo(() => _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled, A<CancellationToken>._))
-            .ReturnsLazily(call =>
-            {
-                cts.Cancel();
-                return Task.FromException(new OperationCanceledException(cts.Token));
-            });
-
-        A.CallTo(() => _taskRepository.GetByIdAsync(timerId, A<CancellationToken>._))
-            .Returns(BuildTimerDocument(timerId, ScheduledTaskStatus.Cancelled));
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => _skill.CancelTimerAsync(timerId, cts.Token));
-
-        // Durable state is Cancelled — the in-memory task must not be resurrected as a ghost.
+        // Timer must stay removed regardless of whether the first write committed.
         Assert.Equal(0, _skill.ActiveTimerCount);
     }
 
@@ -365,20 +343,6 @@ public sealed class TimerSkillTests
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => _skill.ListTimers(cts.Token));
     }
-
-    /// <summary>
-    /// Builds a minimal timer document with a given persisted status for read-back reconciliation tests.
-    /// </summary>
-    private static ScheduledTaskDocument BuildTimerDocument(string id, ScheduledTaskStatus status)
-        => new()
-        {
-            Id = id,
-            TaskId = Guid.NewGuid().ToString("N"),
-            Label = "Timer",
-            FireAt = DateTimeOffset.UtcNow.AddMinutes(5),
-            TaskType = ScheduledTaskType.Timer,
-            Status = status
-        };
 
     /// <summary>
     /// Extracts the timer ID from a SetTimer result string like "Timer 'abc12345' set for ...".

--- a/lucia.Tests/Timer/TimerSkillTests.cs
+++ b/lucia.Tests/Timer/TimerSkillTests.cs
@@ -234,6 +234,20 @@ public sealed class TimerSkillTests
     }
 
     [Fact]
+    public async Task SetTimerAsync_PreCancelledToken_ThrowsWithoutPersistingOrScheduling()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _skill.SetTimerAsync(120, "Never fires", "assist_satellite.kitchen", cts.Token));
+
+        A.CallTo(() => _taskRepository.UpsertAsync(A<ScheduledTaskDocument>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        Assert.Equal(0, _skill.ActiveTimerCount);
+    }
+
+    [Fact]
     public async Task SetTimerAsync_CallerCancelled_RepositoryOce_IsNotSwallowed()
     {
         using var cts = new CancellationTokenSource();

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -148,8 +148,9 @@ public sealed class TimerSkill
     /// <summary>
     /// Cancels an active timer.
     /// </summary>
-    public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
+public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_taskStore.TryRemove(timerId, out _))
         {
             try

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -160,10 +160,33 @@ public sealed class TimerSkill
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Restore the removed task so the in-memory store stays consistent with the
-                // persisted Pending/Active status; prevents ScheduledTaskRecoveryService from
-                // resurrecting the task after a restart.
-                _taskStore.Add(removedTask!);
+                // Mongo may have durably committed Cancelled and *still* surfaced an OCE as the
+                // caller's token unwound. Blindly restoring would resurrect a ghost timer that fires
+                // despite being cancelled. Read the persisted status back (uncancellable) and only
+                // restore when the write clearly did not land — i.e. the record is still recoverable
+                // (Pending/Active), which is exactly what ScheduledTaskRecoveryService would resurrect.
+                // Leave it removed for Cancelled, any terminal state, or a missing document.
+                ScheduledTaskStatus? persistedStatus;
+                try
+                {
+                    var persisted = await _taskRepository.GetByIdAsync(timerId, CancellationToken.None).ConfigureAwait(false);
+                    persistedStatus = persisted?.Status;
+                }
+                catch (Exception readEx)
+                {
+                    // The read-back itself failed, so the persisted status is unknown. Prefer leaving
+                    // the task removed: this avoids ghost firing in-process if Cancelled did commit,
+                    // and defers to durable recovery to resurrect it on restart if it was still
+                    // Pending/Active. Resurrecting here risks an unwanted announcement with no undo.
+                    _logger.LogWarning(readEx, "Failed to read back task {TimerId} after cancelled status update — leaving it removed", timerId);
+                    persistedStatus = null;
+                }
+
+                if (persistedStatus is ScheduledTaskStatus.Pending or ScheduledTaskStatus.Active)
+                {
+                    _taskStore.Add(removedTask!);
+                }
+
                 throw;
             }
             catch (Exception ex)

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -152,7 +152,7 @@ public sealed class TimerSkill
     public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (_taskStore.TryRemove(timerId, out _))
+        if (_taskStore.TryRemove(timerId, out var removedTask))
         {
             try
             {
@@ -160,6 +160,10 @@ public sealed class TimerSkill
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                // Restore the removed task so the in-memory store stays consistent with the
+                // persisted Pending/Active status; prevents ScheduledTaskRecoveryService from
+                // resurrecting the task after a restart.
+                _taskStore.Add(removedTask!);
                 throw;
             }
             catch (Exception ex)

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -148,7 +148,7 @@ public sealed class TimerSkill
     /// <summary>
     /// Cancels an active timer.
     /// </summary>
-public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
+    public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         if (_taskStore.TryRemove(timerId, out _))

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -152,7 +152,7 @@ public sealed class TimerSkill
     public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (_taskStore.TryRemove(timerId, out var removedTask))
+        if (_taskStore.TryRemove(timerId, out _))
         {
             try
             {
@@ -160,33 +160,19 @@ public sealed class TimerSkill
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // Mongo may have durably committed Cancelled and *still* surfaced an OCE as the
-                // caller's token unwound. Blindly restoring would resurrect a ghost timer that fires
-                // despite being cancelled. Read the persisted status back (uncancellable) and only
-                // restore when the write clearly did not land — i.e. the record is still recoverable
-                // (Pending/Active), which is exactly what ScheduledTaskRecoveryService would resurrect.
-                // Leave it removed for Cancelled, any terminal state, or a missing document.
-                ScheduledTaskStatus? persistedStatus;
+                // The caller cancelled while the first write was in-flight. That write may commit
+                // Cancelled after the OCE surfaces (late-commit). Writing the same terminal state
+                // with an uncancellable token is idempotent: both the original write and this
+                // compensation converge on Cancelled regardless of ordering, so the in-memory
+                // removal cannot reintroduce a live timer.
                 try
                 {
-                    var persisted = await _taskRepository.GetByIdAsync(timerId, CancellationToken.None).ConfigureAwait(false);
-                    persistedStatus = persisted?.Status;
+                    await _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled, CancellationToken.None).ConfigureAwait(false);
                 }
-                catch (Exception readEx)
+                catch (Exception compensationEx)
                 {
-                    // The read-back itself failed, so the persisted status is unknown. Prefer leaving
-                    // the task removed: this avoids ghost firing in-process if Cancelled did commit,
-                    // and defers to durable recovery to resurrect it on restart if it was still
-                    // Pending/Active. Resurrecting here risks an unwanted announcement with no undo.
-                    _logger.LogWarning(readEx, "Failed to read back task {TimerId} after cancelled status update — leaving it removed", timerId);
-                    persistedStatus = null;
+                    _logger.LogWarning(compensationEx, "Failed to converge task {TimerId} to Cancelled after caller cancellation; durable recovery will reconcile on restart", timerId);
                 }
-
-                if (persistedStatus is ScheduledTaskStatus.Pending or ScheduledTaskStatus.Active)
-                {
-                    _taskStore.Add(removedTask!);
-                }
-
                 throw;
             }
             catch (Exception ex)

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -75,6 +75,7 @@ public sealed class TimerSkill
     /// </summary>
     public async Task<string> SetTimerAsync(int durationSeconds, string message, string entityId, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var activity = ActivitySource.StartActivity("TimerSkill.SetTimer", ActivityKind.Internal);
 
         if (durationSeconds <= 0)

--- a/lucia.TimerAgent/TimerSkill.cs
+++ b/lucia.TimerAgent/TimerSkill.cs
@@ -73,7 +73,7 @@ public sealed class TimerSkill
     /// Sets a timer that will play a TTS announcement on the specified satellite device when it expires.
     /// The timer is added to <see cref="ScheduledTaskStore"/> and executed by <see cref="ScheduledTaskService"/>.
     /// </summary>
-    public async Task<string> SetTimerAsync(int durationSeconds, string message, string entityId)
+    public async Task<string> SetTimerAsync(int durationSeconds, string message, string entityId, CancellationToken cancellationToken = default)
     {
         using var activity = ActivitySource.StartActivity("TimerSkill.SetTimer", ActivityKind.Internal);
 
@@ -93,7 +93,7 @@ public sealed class TimerSkill
         }
 
         // Resolve location name to an actual assist_satellite entity_id
-        var resolvedEntityId = await ResolveSatelliteEntityAsync(entityId).ConfigureAwait(false);
+        var resolvedEntityId = await ResolveSatelliteEntityAsync(entityId, cancellationToken).ConfigureAwait(false);
         if (resolvedEntityId is null)
         {
             return $"Could not find an assist_satellite device in '{entityId}'. Available satellites can be found in areas with voice assistant devices.";
@@ -124,7 +124,11 @@ public sealed class TimerSkill
         // Persist to MongoDB for crash recovery
         try
         {
-            await _taskRepository.UpsertAsync(timerTask.ToDocument()).ConfigureAwait(false);
+            await _taskRepository.UpsertAsync(timerTask.ToDocument(), cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -144,13 +148,17 @@ public sealed class TimerSkill
     /// <summary>
     /// Cancels an active timer.
     /// </summary>
-    public async Task<string> CancelTimerAsync(string timerId)
+    public async Task<string> CancelTimerAsync(string timerId, CancellationToken cancellationToken = default)
     {
         if (_taskStore.TryRemove(timerId, out _))
         {
             try
             {
-                await _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled).ConfigureAwait(false);
+                await _taskRepository.UpdateStatusAsync(timerId, ScheduledTaskStatus.Cancelled, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -167,8 +175,10 @@ public sealed class TimerSkill
     /// <summary>
     /// Lists all active timers.
     /// </summary>
-    public Task<string> ListTimers()
+    public Task<string> ListTimers(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var timers = _taskStore.GetByType(ScheduledTaskType.Timer);
         if (timers.Count == 0)
         {
@@ -204,7 +214,7 @@ public sealed class TimerSkill
     /// Otherwise, searches the entity location service for assist_satellite entities in that area,
     /// filtering to those that support the <see cref="AssistSatelliteFeature.Announce"/> capability.
     /// </summary>
-    private async Task<string?> ResolveSatelliteEntityAsync(string input)
+    private async Task<string?> ResolveSatelliteEntityAsync(string input, CancellationToken cancellationToken)
     {
         // Already a full entity_id — use as-is
         if (input.Contains('.'))
@@ -216,7 +226,7 @@ public sealed class TimerSkill
         var entities = await _entityLocationService.FindEntitiesByLocationAsync(
             input,
             domainFilter: ["assist_satellite"],
-            ct: default).ConfigureAwait(false);
+            ct: cancellationToken).ConfigureAwait(false);
 
         if (entities.Count > 0)
         {


### PR DESCRIPTION
Completes the three async-deadline concerns from #171 using the existing linked-CTS + `TimeProvider` pattern (mirrors `LocalAgentInvoker`) with one timeout classification: an internal deadline surfaces `TimeoutException` (recorded distinctly), while caller cancellation always propagates as `OperationCanceledException` unchanged.

## Changes
- **TimerSkill:** thread an optional `CancellationToken` through `SetTimerAsync`, `CancelTimerAsync`, `ListTimers`, and `ResolveSatelliteEntityAsync` into every repository/entity I/O; rethrow caller cancellation before the generic catches so it is never swallowed.
- **HomeAssistantClient.SendWebSocketCommandAsync:** bound the connect -> auth -> command -> read sequence with the configured positive `TimeoutSeconds` via a new internal `AsyncDeadline` helper, and bound the finally-block close/cleanup with its own timeout instead of `CancellationToken.None`.
- **EvalHarness:** add validated `AgentTimeout`/`JudgeTimeout` config (zero/negative rejected at startup) and an internal `LlmDeadline` helper wrapping every named LLM site (EvalRunner agent run + `llm_task_completion` judge, PersonalityJudge, PersonalityEvalRunner, PromptOptimizer). Timeouts are recorded as distinct `TimedOut` metadata; no generic zero score without timeout metadata.

Deterministic `FakeTimeProvider` tests fire each deadline while the operation is genuinely in-flight (not a pre-cancel). No suppressions added; no unrelated pre-existing catches modified.

## Validation
- Build: succeeds, 0 warnings/errors.
- Focused deadline/timer tests: 33/33 pass. EvalHarness tests: 47/47 pass.
- Slopwatch (`--no-baseline --fail-on warning`): only pre-existing findings, none introduced by this diff.

Fixes #171