### PR TITLE
fix(auth): stop recording API key validation usage

### DIFF
--- a/lucia.Agents/Abstractions/IApiKeyService.cs
+++ b/lucia.Agents/Abstractions/IApiKeyService.cs
@@ -20,7 +20,7 @@ public interface IApiKeyService
 
     /// <summary>
     /// Validates an API key. Returns the entry if valid, null if invalid/revoked/expired.
-    /// Updates LastUsedAt on success.
+    /// Validation is read-only and does not update LastUsedAt.
     /// </summary>
     Task<ApiKeyEntry?> ValidateKeyAsync(string plaintextKey, CancellationToken cancellationToken = default);
 

--- a/lucia.Agents/Auth/ApiKeyEntry.cs
+++ b/lucia.Agents/Auth/ApiKeyEntry.cs
@@ -41,7 +41,7 @@ public sealed class ApiKeyEntry
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
 
     /// <summary>
-    /// When this key was last used for authentication. Null if never used.
+    /// Historical last-used authentication timestamp. Validation does not update this field.
     /// </summary>
     [BsonElement("lastUsedAt")]
     public DateTime? LastUsedAt { get; set; }

--- a/lucia.Agents/Auth/MongoApiKeyService.cs
+++ b/lucia.Agents/Auth/MongoApiKeyService.cs
@@ -114,16 +114,6 @@ public sealed class MongoApiKeyService : IApiKeyService
             return null;
         }
 
-        // Update last used timestamp (fire-and-forget for performance — intentionally
-        // uses CancellationToken.None so the update completes even if the request ends)
-        var update = Builders<ApiKeyEntry>.Update.Set(k => k.LastUsedAt, DateTime.UtcNow);
-        _ = _collection.UpdateOneAsync(k => k.Id == entry.Id, update, cancellationToken: CancellationToken.None)
-            .ContinueWith(t =>
-            {
-                if (t.IsFaulted)
-                    _logger.LogWarning(t.Exception!.InnerException, "Failed to update LastUsedAt for API key '{KeyId}'", entry.Id);
-            }, TaskScheduler.Default);
-
         return entry;
     }
 

--- a/lucia.Data/PostgreSQL/PostgresApiKeyService.cs
+++ b/lucia.Data/PostgreSQL/PostgresApiKeyService.cs
@@ -138,23 +138,6 @@ public sealed partial class PostgresApiKeyService : IApiKeyService
             return null;
         }
 
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await using var conn = await _connectionFactory.CreateConnectionAsync(CancellationToken.None).ConfigureAwait(false);
-                await using var updateCmd = conn.CreateCommand();
-                updateCmd.CommandText = "UPDATE api_keys SET last_used_at = @lastUsedAt WHERE id = @id;";
-                updateCmd.Parameters.AddWithValue("lastUsedAt", DateTime.UtcNow);
-                updateCmd.Parameters.AddWithValue("id", entry.Id);
-                await updateCmd.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                LogLastUsedUpdateFailed(_logger, ex, entry.Id);
-            }
-        });
-
         return entry;
     }
 
@@ -378,9 +361,6 @@ public sealed partial class PostgresApiKeyService : IApiKeyService
 
     [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Created API key '{Name}' from env (prefix {Prefix})")]
     private static partial void LogCreatedEnvKey(ILogger logger, string name, string prefix);
-
-    [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "Failed to update LastUsedAt for API key '{KeyId}'")]
-    private static partial void LogLastUsedUpdateFailed(ILogger logger, Exception exception, string keyId);
 
     [LoggerMessage(EventId = 4, Level = LogLevel.Information, Message = "Revoked API key '{Name}' ({Prefix})")]
     private static partial void LogRevokedKey(ILogger logger, string name, string prefix);

--- a/lucia.Data/Sqlite/SqliteApiKeyService.cs
+++ b/lucia.Data/Sqlite/SqliteApiKeyService.cs
@@ -133,25 +133,6 @@ public sealed class SqliteApiKeyService : IApiKeyService
         if (entry.ExpiresAt.HasValue && entry.ExpiresAt.Value < DateTime.UtcNow)
             return null;
 
-        // Fire-and-forget last-used update (intentionally uses CancellationToken.None
-        // so the update completes even if the request ends)
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                using var conn = _connectionFactory.CreateConnection();
-                using var updateCmd = conn.CreateCommand();
-                updateCmd.CommandText = "UPDATE api_keys SET last_used_at = @lastUsedAt WHERE id = @id;";
-                updateCmd.Parameters.AddWithValue("@lastUsedAt", DateTime.UtcNow.ToString("O"));
-                updateCmd.Parameters.AddWithValue("@id", entry.Id);
-                await updateCmd.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to update LastUsedAt for API key '{KeyId}'", entry.Id);
-            }
-        });
-
         return entry;
     }
 

--- a/lucia.Tests/Auth/MongoApiKeyServiceTests.cs
+++ b/lucia.Tests/Auth/MongoApiKeyServiceTests.cs
@@ -58,10 +58,11 @@ public class MongoApiKeyServiceTests
     }
 
     [Fact]
-    public async Task ValidateKeyAsync_ReturnsEntryForValidKey()
+    public async Task ValidateKeyAsync_ReturnsEntryForValidKeyWithoutWriting()
     {
         var plaintextKey = "lk_test-valid-key-abc123";
         var hash = ComputeSha256Hash(plaintextKey);
+        var lastUsedAt = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
         var entry = new ApiKeyEntry
         {
             Id = "entry-1",
@@ -69,15 +70,21 @@ public class MongoApiKeyServiceTests
             KeyPrefix = "lk_test-vali...",
             Name = "Valid Key",
             IsRevoked = false,
+            LastUsedAt = lastUsedAt,
+            Scopes = ["read:test"],
         };
 
         SetupFindAsync(entry);
-        SetupUpdateOneAsync(1);
 
         var result = await _service.ValidateKeyAsync(plaintextKey);
 
         Assert.NotNull(result);
         Assert.Equal("entry-1", result.Id);
+        Assert.Equal(lastUsedAt, result.LastUsedAt);
+        Assert.Equal(["read:test"], result.Scopes);
+        A.CallTo(_collection)
+            .Where(call => call.Method.Name == "UpdateOneAsync")
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/lucia.Tests/Data/SqliteApiKeyServiceTests.cs
+++ b/lucia.Tests/Data/SqliteApiKeyServiceTests.cs
@@ -39,6 +39,71 @@ public sealed class SqliteApiKeyServiceTests : IDisposable
         Assert.Equal("validate-key", entry.Name);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ValidateKeyAsync_DoesNotUpdateLastUsedAt(bool hasHistoricalValue)
+    {
+        var created = await _service.CreateKeyAsync("read-only-validation");
+        var expectedLastUsedAt = hasHistoricalValue
+            ? new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+            : (DateTime?)null;
+        var expectedStoredValue = expectedLastUsedAt?.ToString("O");
+
+        using (var connection = _helper.ConnectionFactory.CreateConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "UPDATE api_keys SET last_used_at = @lastUsedAt, scopes = @scopes WHERE id = @id;";
+            command.Parameters.AddWithValue("@lastUsedAt", expectedStoredValue ?? (object)DBNull.Value);
+            command.Parameters.AddWithValue("@scopes", """["read:test"]""");
+            command.Parameters.AddWithValue("@id", created.Id);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        var entry = await _service.ValidateKeyAsync(created.Key);
+        var storedLastUsedAt = expectedStoredValue;
+
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            using var connection = _helper.ConnectionFactory.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT last_used_at FROM api_keys WHERE id = @id;";
+            command.Parameters.AddWithValue("@id", created.Id);
+            var value = await command.ExecuteScalarAsync();
+            storedLastUsedAt = value as string;
+            if (storedLastUsedAt != expectedStoredValue)
+            {
+                break;
+            }
+
+            await Task.Yield();
+        }
+
+        Assert.NotNull(entry);
+        Assert.Equal(expectedLastUsedAt, entry.LastUsedAt?.ToUniversalTime());
+        Assert.Equal(["read:test"], entry.Scopes);
+        Assert.Equal(expectedStoredValue, storedLastUsedAt);
+    }
+
+    [Fact]
+    public async Task ValidateKeyAsync_ReturnsNull_ForExpiredKey()
+    {
+        var created = await _service.CreateKeyAsync("expired-key");
+
+        using (var connection = _helper.ConnectionFactory.CreateConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "UPDATE api_keys SET expires_at = @expiresAt WHERE id = @id;";
+            command.Parameters.AddWithValue("@expiresAt", DateTime.UtcNow.AddMinutes(-1).ToString("O"));
+            command.Parameters.AddWithValue("@id", created.Id);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        var entry = await _service.ValidateKeyAsync(created.Key);
+
+        Assert.Null(entry);
+    }
+
     [Fact]
     public async Task ValidateKeyAsync_ReturnsNull_ForInvalidKey()
     {


### PR DESCRIPTION
## Summary
- Stop authentication from writing `LastUsedAt` in SQLite, PostgreSQL, and MongoDB.
- Retain nullable fields, columns, mappings, and serialization for compatibility.

## Tests
- `dotnet build lucia-dotnet.slnx` (passed)
- Provider-free authentication tests: 82 passed
- Baseline-free Slopwatch: 0 findings
- Full suite: 1,131 passed, 141 external embedding/LLM eval failures, 155 skipped

Fixes #128