### PR TITLE
fix(infra): correct Docker Hub image name in Jetson compose file

### DIFF
--- a/infra/docker/docker-compose.jetson.yml
+++ b/infra/docker/docker-compose.jetson.yml
@@ -164,7 +164,7 @@ services:
       cache_from:
         - lucia:jetson
 
-    image: lucia:jetson
+    image: seiggy/lucia-agenthost:jetson
 
     container_name: lucia-jetson
 


### PR DESCRIPTION
This pull request updates the Docker image used for the Jetson service in the `docker-compose.jetson.yml` file. The service now uses the `seiggy/lucia-agenthost:jetson` image instead of the previously referenced local `lucia:jetson` image. This change ensures the service pulls the image from a remote repository, which can help with consistency and deployment.

- Changed the Jetson service image in `docker-compose.jetson.yml` to use `seiggy/lucia-agenthost:jetson` instead of the local `lucia:jetson` image.