### PR TITLE
chore(agents): update governance defaults

### DIFF
--- a/.copilot/skills/economy-mode/SKILL.md
+++ b/.copilot/skills/economy-mode/SKILL.md
@@ -40,7 +40,7 @@ When economy mode is **active**, Layer 3 auto-selection uses this table instead 
 
 | Task Output | Normal Mode | Economy Mode |
 |-------------|-------------|--------------|
-| Writing code (implementation, refactoring, bug fixes) | `claude-sonnet-4.5` | `gpt-4.1` or `gpt-5-mini` |
+| Writing code (implementation, refactoring, bug fixes) | `mai-code-1.1-flash` | `gpt-4.1` or `gpt-5-mini` |
 | Writing prompts or agent designs | `claude-sonnet-4.5` | `gpt-4.1` or `gpt-5-mini` |
 | Docs, planning, triage, changelogs, mechanical ops | `claude-haiku-4.5` | `gpt-4.1` or `gpt-5-mini` |
 | Architecture, code review, security audits | `claude-opus-4.5` | `claude-sonnet-4.5` |

--- a/.copilot/skills/model-selection/SKILL.md
+++ b/.copilot/skills/model-selection/SKILL.md
@@ -28,7 +28,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 | **0b** | Global Config | `.squad/config.json` → `defaultModel` | Persistent (survives sessions) |
 | **1** | Session Directive | User said "use X" in current session | Session-only |
 | **2** | Charter Preference | Agent's `charter.md` → `## Model` section | Persistent (in charter) |
-| **3** | Task-Aware Auto | Code → sonnet, docs → haiku, visual → opus | Computed per-spawn |
+| **3** | Task-Aware Auto | Code → `mai-code-1.1-flash`, docs → haiku, visual → opus | Computed per-spawn |
 | **4** | Default | `claude-haiku-4.5` | Hardcoded fallback |
 
 **Key principle:** Layer 0 (persistent config) beats everything. If the user said "always use opus" and it was saved to config.json, every agent gets opus regardless of role or task type. This is intentional — the user explicitly chose quality over cost.
@@ -49,7 +49,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 3. CHECK Layer 1: Did the user give a session directive? → Use it.
 4. CHECK Layer 2: Does the agent's charter have a `## Model` section? → Use it.
 5. CHECK Layer 3: Determine task type:
-   - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
+   - Code (implementation, tests, refactoring, bug fixes) → `mai-code-1.1-flash`
    - Prompts, agent designs → `claude-sonnet-4.6`
    - Visual/design with image analysis → `claude-opus-4.6`
    - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
@@ -110,7 +110,7 @@ If a model is unavailable (rate limit, plan restriction), retry within the same 
 
 ```
 Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
+Standard: mai-code-1.1-flash → claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
 Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini
 ```
 

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -260,6 +260,8 @@ The routing table determines **WHO** handles work. After routing, use Response M
 
 If a matching skill exists, add to the spawn prompt: `Relevant skill: {path}/SKILL.md — read before starting.` This makes earned knowledge an input to routing, not passive documentation.
 
+**UI workflow (mandatory):** Every agent doing frontend, UI, UX, or visual design work must first invoke the `impeccable` skill and follow `.github/skills/impeccable/SKILL.md`. Include that requirement in the spawn prompt; generic skill discovery is not sufficient.
+
 ### Consult Mode Detection
 
 When a user addresses a personal agent by name:
@@ -370,7 +372,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 
 | Task Output | Model | Tier | Rule |
 |-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
+| Writing code (implementation, refactoring, test code, bug fixes) | `mai-code-1.1-flash` | Standard | Default coding model for sub-agents. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
 | Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
@@ -379,8 +381,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 
 | Role | Default Model | Why | Override When |
 |------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
+| Core Dev / Backend / Frontend | `mai-code-1.1-flash` | Default for code-writing work | — |
+| Tester / QA | `mai-code-1.1-flash` | Default when writing test code | Non-code test planning → `claude-haiku-4.5` |
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
@@ -392,7 +394,6 @@ Before spawning an agent, determine which model to use. Check these layers in or
 **Task complexity adjustments** (apply at most ONE — no cascading):
 - **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
 - **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
 - **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
 
 **Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
@@ -403,7 +404,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
+Standard: mai-code-1.1-flash → claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
 ```
 
@@ -437,7 +438,7 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
+🔧 Fenster (mai-code-1.1-flash) — refactoring auth module
 🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
 ⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
@@ -449,7 +450,7 @@ Include tier annotation only when the model was bumped or a specialist was chose
 **Valid models (current platform catalog):**
 
 Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
+Standard: `mai-code-1.1-flash`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
 
 ### Client Compatibility

--- a/.squad/agents/vasquez/charter.md
+++ b/.squad/agents/vasquez/charter.md
@@ -35,7 +35,7 @@ For each branch under review (run from inside that branch's worktree):
    - **Test-first / tests present** for public behavior changes.
    - Nullable reference types, file-scoped namespaces, `[LoggerMessage]` logging, OpenTelemetry instrumentation retained (not removed/disabled).
    - **Conventional Commits** + `Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>` trailer; body ends with `Fixes #N`/`Closes #N`.
-6. **Doc accuracy.** XML docs, comments, and `.squad` history entries must match the actual implementation.
+6. **Documentation completeness.** Verify the PR updates every affected documentation surface, including XML docs, repository README files, product/spec docs, examples, and `.squad` history. If no documentation is affected, state that explicitly in the verdict.
 7. **Verdict.**
    - **APPROVE** → record approval for the exact HEAD SHA (see Approval Mechanism). The branch may now be pushed / PR'd / merged.
    - **REQUEST-CHANGES** → produce a numbered, file:line checklist of every BLOCKING problem, plus any non-blocking nits marked clearly. The branch stays blocked. The author fixes and I re-review the new HEAD.

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -59,6 +59,7 @@
 2. Build + run relevant tests; separate real regressions from the known pre-existing eval-test failures.
 3. Correctness pass: concurrency, resource leaks, null/auth/edge cases, security.
 4. Constitution pass: one-class-per-file, tests present, nullable, telemetry retained, Conventional Commits + trailer.
-5. Verdict: **APPROVE** → record approval marker for HEAD SHA (`.squad/gate/Approve-Branch.ps1`); **REQUEST-CHANGES** → numbered file:line blocking checklist, branch stays blocked, author fixes, re-review.
+5. Documentation pass: verify all affected README, product/spec, API/XML, example, and repository documentation is updated; otherwise record why no documentation change is needed.
+6. Verdict: **APPROVE** → record approval marker for HEAD SHA (`.squad/gate/Approve-Branch.ps1`); **REQUEST-CHANGES** → numbered file:line blocking checklist, branch stays blocked, author fixes, re-review.
 
 > Vasquez runs on **GPT-5.6 Sol only**. No `squad/*` branch is pushed, PR'd, or merged without an APPROVE. The `.githooks/pre-push` hook mechanically blocks the push (the prerequisite for any PR/merge); PR and merge gating are governance.

--- a/.squad/config.json
+++ b/.squad/config.json
@@ -2,9 +2,6 @@
   "version": 1,
   "worktrees": "true",
   "agentModelOverrides": {
-    "ripley": "claude-opus-4.8",
-    "dallas": "claude-opus-4.8",
-    "brett": "claude-opus-4.8",
     "vasquez": "gpt-5.6-sol"
   }
 }

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -308,6 +308,11 @@ No tight CPU spin was found. The idle CPU is most likely the **aggregate effect*
 **What:** All agents responsible for writing code should prefer Claude Opus 4.8 (`claude-opus-4.8`) as their model. Non-code agents (Scribe, Ralph) remain on their defaults.
 **Why:** User request — captured for team memory
 
+### 2026-08-18T13:09:53-04:00: User directive
+**By:** Zack Way (via Copilot)
+**What:** Supersede the prior coding-model preference with `mai-code-1.1-flash`; require Impeccable workflows for all UI work; and require Vasquez's pre-push review to verify affected documentation and README updates.
+**Why:** User request — captured for team memory
+
 
 ---
 

--- a/.squad/gate/README.md
+++ b/.squad/gate/README.md
@@ -80,7 +80,9 @@ $env:SQUAD_GATE_BYPASS = "1"; git push; Remove-Item Env:SQUAD_GATE_BYPASS
 ## The rule
 
 No `squad/*` branch is pushed, turned into a PR, or merged to `master` until
-Vasquez has reviewed the branch diff and every blocking problem is resolved.
+Vasquez has reviewed the branch diff, verified that all affected documentation
+and README files are updated (or documented why none are affected), and every
+blocking problem is resolved.
 This is enforced by the coordinator (governance — see `routing.md` and
 `decisions.md`); the `.githooks/pre-push` hook is the mechanical backstop that
 blocks the push itself — the prerequisite for any PR or merge.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -24,6 +24,10 @@ merge. Any new commit after approval invalidates it and requires a fresh review.
 Vasquez runs on **GPT-5.6 Sol only** (locked in `.squad/config.json`); a review on
 any other model is not valid.
 
+The review must also verify that the PR updates every affected documentation
+surface, including repository README files. If no documentation is affected,
+Vasquez records that conclusion in the verdict before approving.
+
 ## Routing Table
 
 | Work Type | Route To | Examples |
@@ -116,3 +120,4 @@ any other model is not valid.
 6. **Anticipate downstream work.** If a feature is being built, spawn the tester to write test cases from requirements simultaneously.
 7. **Issue-labeled work** — when a `squad:{member}` label is applied to an issue, route to that member. Ripley handles all `squad` (base label) triage.
 8. **Pre-push review gate is mandatory.** Never let an agent push a `squad/*` branch or open a PR before Vasquez has reviewed it and recorded an APPROVE. On REQUEST-CHANGES, the branch author fixes and Vasquez re-reviews. The git `pre-push` hook mechanically blocks the push — the prerequisite for any PR — as a backstop. Vasquez is model-locked to `gpt-5.6-sol`.
+9. **Impeccable is mandatory for UI work.** Any agent working on frontend, UI, UX, or visual design must invoke the `impeccable` skill first and follow `.github/skills/impeccable/SKILL.md`.

--- a/.squad/templates/skills/economy-mode/SKILL.md
+++ b/.squad/templates/skills/economy-mode/SKILL.md
@@ -40,7 +40,7 @@ When economy mode is **active**, Layer 3 auto-selection uses this table instead 
 
 | Task Output | Normal Mode | Economy Mode |
 |-------------|-------------|--------------|
-| Writing code (implementation, refactoring, bug fixes) | `claude-sonnet-4.5` | `gpt-4.1` or `gpt-5-mini` |
+| Writing code (implementation, refactoring, bug fixes) | `mai-code-1.1-flash` | `gpt-4.1` or `gpt-5-mini` |
 | Writing prompts or agent designs | `claude-sonnet-4.5` | `gpt-4.1` or `gpt-5-mini` |
 | Docs, planning, triage, changelogs, mechanical ops | `claude-haiku-4.5` | `gpt-4.1` or `gpt-5-mini` |
 | Architecture, code review, security audits | `claude-opus-4.5` | `claude-sonnet-4.5` |

--- a/.squad/templates/skills/model-selection/SKILL.md
+++ b/.squad/templates/skills/model-selection/SKILL.md
@@ -28,7 +28,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 | **0b** | Global Config | `.squad/config.json` → `defaultModel` | Persistent (survives sessions) |
 | **1** | Session Directive | User said "use X" in current session | Session-only |
 | **2** | Charter Preference | Agent's `charter.md` → `## Model` section | Persistent (in charter) |
-| **3** | Task-Aware Auto | Code → sonnet, docs → haiku, visual → opus | Computed per-spawn |
+| **3** | Task-Aware Auto | Code → `mai-code-1.1-flash`, docs → haiku, visual → opus | Computed per-spawn |
 | **4** | Default | `claude-haiku-4.5` | Hardcoded fallback |
 
 **Key principle:** Layer 0 (persistent config) beats everything. If the user said "always use opus" and it was saved to config.json, every agent gets opus regardless of role or task type. This is intentional — the user explicitly chose quality over cost.
@@ -49,7 +49,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 3. CHECK Layer 1: Did the user give a session directive? → Use it.
 4. CHECK Layer 2: Does the agent's charter have a `## Model` section? → Use it.
 5. CHECK Layer 3: Determine task type:
-   - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
+   - Code (implementation, tests, refactoring, bug fixes) → `mai-code-1.1-flash`
    - Prompts, agent designs → `claude-sonnet-4.6`
    - Visual/design with image analysis → `claude-opus-4.6`
    - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
@@ -110,7 +110,7 @@ If a model is unavailable (rate limit, plan restriction), retry within the same 
 
 ```
 Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
+Standard: mai-code-1.1-flash → claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
 Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini
 ```
 

--- a/.squad/templates/squad.agent.md
+++ b/.squad/templates/squad.agent.md
@@ -248,6 +248,8 @@ The routing table determines **WHO** handles work. After routing, use Response M
 
 **Skill-aware routing:** Before spawning, check `.squad/skills/` for skills relevant to the task domain. If a matching skill exists, add to the spawn prompt: `Relevant skill: .squad/skills/{name}/SKILL.md — read before starting.` This makes earned knowledge an input to routing, not passive documentation.
 
+**UI workflow (mandatory):** Every agent doing frontend, UI, UX, or visual design work must first invoke the `impeccable` skill and follow `.github/skills/impeccable/SKILL.md`. Include that requirement in the spawn prompt; generic skill discovery is not sufficient.
+
 ### Consult Mode Detection
 
 When a user addresses a personal agent by name:
@@ -356,7 +358,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 
 | Task Output | Model | Tier | Rule |
 |-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.5` | Standard | Quality and accuracy matter for code. Use standard tier. |
+| Writing code (implementation, refactoring, test code, bug fixes) | `mai-code-1.1-flash` | Standard | Default coding model for sub-agents. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.5` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
 | Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
@@ -365,8 +367,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 
 | Role | Default Model | Why | Override When |
 |------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.5` | Writes code — quality first | Heavy code gen → `gpt-5.2-codex` |
-| Tester / QA | `claude-sonnet-4.5` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
+| Core Dev / Backend / Frontend | `mai-code-1.1-flash` | Default for code-writing work | — |
+| Tester / QA | `mai-code-1.1-flash` | Default when writing test code | Non-code test planning → `claude-haiku-4.5` |
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.5` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
@@ -378,7 +380,6 @@ Before spawning an agent, determine which model to use. Check these layers in or
 **Task complexity adjustments** (apply at most ONE — no cascading):
 - **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
 - **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.2-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
 - **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
 
 **Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
@@ -389,7 +390,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.5 → gpt-5.2-codex → claude-sonnet-4 → gpt-5.2 → (omit model param)
+Standard: mai-code-1.1-flash → claude-sonnet-4.5 → gpt-5.2-codex → gpt-5.2 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini → (omit model param)
 ```
 
@@ -422,7 +423,7 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.5) — refactoring auth module
+🔧 Fenster (mai-code-1.1-flash) — refactoring auth module
 🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
 ⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
@@ -434,7 +435,7 @@ Include tier annotation only when the model was bumped or a specialist was chose
 **Valid models (current platform catalog):**
 
 Premium: `claude-opus-4.6`, `claude-opus-4.6-fast`, `claude-opus-4.5`
-Standard: `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gpt-5`, `gemini-3-pro-preview`
+Standard: `mai-code-1.1-flash`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gpt-5`, `gemini-3-pro-preview`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
 
 ### Client Compatibility

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -260,6 +260,8 @@ The routing table determines **WHO** handles work. After routing, use Response M
 
 If a matching skill exists, add to the spawn prompt: `Relevant skill: {path}/SKILL.md — read before starting.` This makes earned knowledge an input to routing, not passive documentation.
 
+**UI workflow (mandatory):** Every agent doing frontend, UI, UX, or visual design work must first invoke the `impeccable` skill and follow `.github/skills/impeccable/SKILL.md`. Include that requirement in the spawn prompt; generic skill discovery is not sufficient.
+
 ### Consult Mode Detection
 
 When a user addresses a personal agent by name:
@@ -370,7 +372,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 
 | Task Output | Model | Tier | Rule |
 |-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
+| Writing code (implementation, refactoring, test code, bug fixes) | `mai-code-1.1-flash` | Standard | Default coding model for sub-agents. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
 | Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
@@ -379,8 +381,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 
 | Role | Default Model | Why | Override When |
 |------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
+| Core Dev / Backend / Frontend | `mai-code-1.1-flash` | Default for code-writing work | — |
+| Tester / QA | `mai-code-1.1-flash` | Default when writing test code | Non-code test planning → `claude-haiku-4.5` |
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
@@ -392,7 +394,6 @@ Before spawning an agent, determine which model to use. Check these layers in or
 **Task complexity adjustments** (apply at most ONE — no cascading):
 - **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
 - **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
 - **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
 
 **Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
@@ -403,7 +404,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
+Standard: mai-code-1.1-flash → claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
 ```
 
@@ -437,7 +438,7 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
+🔧 Fenster (mai-code-1.1-flash) — refactoring auth module
 🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
 ⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
@@ -449,7 +450,7 @@ Include tier annotation only when the model was bumped or a specialist was chose
 **Valid models (current platform catalog):**
 
 Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
+Standard: `mai-code-1.1-flash`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
 
 ### Client Compatibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ Refer to `.docs/product/tech-stack.md` for deeper detail and version updates bef
 
 **TDD expectation:** Write or update tests before implementing public behavior changes. Never merge failing tests.
 
+- **Coding sub-agents:** Use `mai-code-1.1-flash` by default for implementation, refactoring, test code, and bug fixes.
+- **UI work:** Invoke `.github/skills/impeccable/SKILL.md` before changing any user interface and follow its workflow.
+- **Pre-push review:** The reviewer must verify that each PR updates all affected documentation, including repository README files, or explicitly confirm that no documentation change is needed.
+
 ## 4. Development Quick Reference
 
 - **Restore & Build:** `dotnet restore`, `dotnet build lucia-dotnet.slnx`

--- a/lucia.Tests/Conversation/ConversationTelemetryBailTests.cs
+++ b/lucia.Tests/Conversation/ConversationTelemetryBailTests.cs
@@ -281,7 +281,7 @@ public sealed class ConversationTelemetryBailTests : IDisposable
     {
         var listener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == "lucia.AgentHost",
+            ShouldListenTo = source => source == _telemetrySource.ActivitySource,
             Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
                 ActivitySamplingResult.AllDataAndRecorded,
         };


### PR DESCRIPTION
## Summary
- default coding sub-agents to `mai-code-1.1-flash`
- require Impeccable workflows for UI work
- extend Vasquez's pre-push review to verify affected documentation and README updates
- keep active Squad governance and future templates aligned

## Validation
- pre-push provider-free test suite: 1,320 passed