### PR TITLE
perf(wyoming): disable unused audio pipelines

### DIFF
--- a/lucia.AgentHost/Apis/WyomingStatusApi.cs
+++ b/lucia.AgentHost/Apis/WyomingStatusApi.cs
@@ -17,8 +17,8 @@ public static class WyomingStatusApi
 
     public static IResult GetWyomingStatus(
         IEnumerable<ISttEngine> sttEngines,
-        IVadEngine? vadEngine,
-        IWakeWordDetector? wakeWordDetector,
+        IEnumerable<IVadEngine> vadEngines,
+        IEnumerable<IWakeWordDetector> wakeWordDetectors,
         IDiarizationEngine? diarizationEngine,
         ISpeechEnhancer? speechEnhancer,
         CustomWakeWordManager? wakeWordManager,
@@ -27,6 +27,10 @@ public static class WyomingStatusApi
     {
         // Pick the engine matching the user's preferred STT engine type
         var engines = sttEngines.ToArray();
+        var vadEngine = vadEngines.FirstOrDefault(static engine => engine.IsReady)
+            ?? vadEngines.FirstOrDefault();
+        var wakeWordDetector = wakeWordDetectors.FirstOrDefault(static detector => detector.IsReady)
+            ?? wakeWordDetectors.FirstOrDefault();
         var preferStreaming = manager.PreferredSttEngineType == EngineType.Stt;
         var activeEngine = preferStreaming
             ? (engines.OfType<SherpaSttEngine>().FirstOrDefault(static e => e.IsReady) as ISttEngine

--- a/lucia.AgentHost/appsettings.json
+++ b/lucia.AgentHost/appsettings.json
@@ -8,7 +8,9 @@
     }
   },
   "FeatureManagement": {
-    "UseCascadingResolver": true
+    "UseCascadingResolver": true,
+    "VadPipeline": false,
+    "WakeWordPipeline": false
   },
   "HomeAssistant": {
     "BaseUrl": "http://homeassistant.local:8123",

--- a/lucia.Tests/Wyoming/WyomingServiceCollectionExtensionsTests.cs
+++ b/lucia.Tests/Wyoming/WyomingServiceCollectionExtensionsTests.cs
@@ -130,6 +130,27 @@ public sealed class WyomingServiceCollectionExtensionsTests
         Assert.Contains(patterns, pattern => pattern.Id == "test-skill-pattern");
     }
 
+    [Fact]
+    public void AddWyomingServer_DoesNotRegisterDisabledVadAndWakeWordPipelines()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["FeatureManagement:VadPipeline"] = "false",
+                ["FeatureManagement:WakeWordPipeline"] = "false",
+            });
+
+        builder.AddWyomingServer();
+
+        Assert.DoesNotContain(
+            builder.Services,
+            descriptor => descriptor.ServiceType == typeof(lucia.Wyoming.Vad.IVadEngine));
+        Assert.DoesNotContain(
+            builder.Services,
+            descriptor => descriptor.ServiceType == typeof(IWakeWordDetector));
+    }
+
     private sealed class TestOptimizablePatternSkill : IOptimizableSkill, ICommandPatternProvider
     {
         public string SkillDisplayName => "Test Skill";

--- a/lucia.Tests/Wyoming/WyomingStatusApiTests.cs
+++ b/lucia.Tests/Wyoming/WyomingStatusApiTests.cs
@@ -8,7 +8,9 @@ using lucia.Wyoming.Models;
 using lucia.Wyoming.Stt;
 using lucia.Wyoming.Vad;
 using lucia.Wyoming.WakeWord;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -22,8 +24,8 @@ public sealed class WyomingStatusApiTests
     {
         var result = WyomingStatusApi.GetWyomingStatus(
             new ISttEngine[] { new TestSttEngine(new TestSttSession(new SttResult())) },
-            null,
-            new TestWakeWordDetector(new TestWakeWordSession(null)),
+            [],
+            [new TestWakeWordDetector(new TestWakeWordSession(null))],
             new TestDiarizationEngine(),
             null,
             CreateReadyManager(),
@@ -44,8 +46,8 @@ public sealed class WyomingStatusApiTests
     {
         var result = WyomingStatusApi.GetWyomingStatus(
             new ISttEngine[] { new UnreadySttEngine() },
-            null,
-            new UnreadyWakeWordDetector(),
+            [],
+            [new UnreadyWakeWordDetector()],
             new UnreadyDiarizationEngine(),
             null,
             CreateUnreadyManager(),
@@ -59,6 +61,35 @@ public sealed class WyomingStatusApiTests
         Assert.False(payload.GetProperty("diarization").GetProperty("ready").GetBoolean());
         Assert.False(payload.GetProperty("customWakeWords").GetProperty("ready").GetBoolean());
         Assert.False(payload.GetProperty("configured").GetBoolean());
+    }
+
+    [Fact]
+    public async Task MapWyomingStatusEndpoints_StartsWithVadAndWakeWordPipelinesDisabled()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["FeatureManagement:VadPipeline"] = "false",
+                ["FeatureManagement:WakeWordPipeline"] = "false",
+                ["urls"] = "http://127.0.0.1:0",
+            });
+        builder.Services.AddSingleton<ISttEngine>(new UnreadySttEngine());
+        builder.Services.AddSingleton<IDiarizationEngine>(new UnreadyDiarizationEngine());
+        builder.Services.AddSingleton(A.Fake<ISpeechEnhancer>());
+        builder.Services.AddSingleton(CreateUnreadyManager());
+        builder.Services.AddSingleton(TestOnnxProvider.Instance);
+        builder.Services.AddSingleton(CreateModelManager());
+
+        await using var app = builder.Build();
+        app.MapWyomingStatusEndpoints();
+
+        await app.StartAsync();
+        using var client = new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
+        using var response = await client.GetAsync("/api/wyoming/status");
+        await app.StopAsync();
+
+        response.EnsureSuccessStatusCode();
     }
 
     private static ModelManager CreateModelManager()

--- a/lucia.Wyoming/Extensions/ServiceCollectionExtensions.cs
+++ b/lucia.Wyoming/Extensions/ServiceCollectionExtensions.cs
@@ -89,8 +89,14 @@ public static class ServiceCollectionExtensions
         builder.Services.AddSingleton<ISttEngine, HybridSttEngine>();
         builder.Services.AddSingleton<ISttEngine, SherpaSttEngine>();
         builder.Services.AddSingleton<IGraniteEngine, GraniteOnnxEngine>();
-        builder.Services.AddSingleton<IVadEngine, SherpaVadEngine>();
-        builder.Services.AddSingleton<IWakeWordDetector, SherpaWakeWordDetector>();
+        if (builder.Configuration.GetValue("FeatureManagement:VadPipeline", true))
+        {
+            builder.Services.AddSingleton<IVadEngine, SherpaVadEngine>();
+        }
+        if (builder.Configuration.GetValue("FeatureManagement:WakeWordPipeline", true))
+        {
+            builder.Services.AddSingleton<IWakeWordDetector, SherpaWakeWordDetector>();
+        }
 
         builder.Services.AddSingleton<IDiarizationEngine, SherpaDiarizationEngine>();
         builder.Services.AddSingleton<ISpeechEnhancer, GtcrnSpeechEnhancer>();

--- a/lucia.Wyoming/Models/ModelStartupValidator.cs
+++ b/lucia.Wyoming/Models/ModelStartupValidator.cs
@@ -17,8 +17,8 @@ namespace lucia.Wyoming.Models;
 public sealed class ModelStartupValidator(
     ModelManager modelManager,
     IEnumerable<ISttEngine> sttEngines,
-    IVadEngine vadEngine,
-    IWakeWordDetector wakeWordDetector,
+    IEnumerable<IVadEngine> vadEngines,
+    IEnumerable<IWakeWordDetector> wakeWordDetectors,
     IDiarizationEngine diarizationEngine,
     ISpeechEnhancer speechEnhancer,
     ILogger<ModelStartupValidator> logger) : BackgroundService
@@ -27,12 +27,18 @@ public sealed class ModelStartupValidator(
     {
         // Engine singletons are resolved via constructor injection to ensure they are
         // constructed and subscribed to ActiveModelChanged before we fire events.
-        _ = (sttEngines, vadEngine, wakeWordDetector, diarizationEngine, speechEnhancer);
+        _ = (sttEngines, vadEngines, wakeWordDetectors, diarizationEngine, speechEnhancer);
 
         await ActivateEngineAsync(EngineType.SpeechEnhancement, stoppingToken).ConfigureAwait(false);
         await ActivateEngineAsync(EngineType.Stt, stoppingToken).ConfigureAwait(false);
-        await ActivateEngineAsync(EngineType.Vad, stoppingToken).ConfigureAwait(false);
-        await ActivateEngineAsync(EngineType.WakeWord, stoppingToken).ConfigureAwait(false);
+        if (vadEngines.Any())
+        {
+            await ActivateEngineAsync(EngineType.Vad, stoppingToken).ConfigureAwait(false);
+        }
+        if (wakeWordDetectors.Any())
+        {
+            await ActivateEngineAsync(EngineType.WakeWord, stoppingToken).ConfigureAwait(false);
+        }
         await ActivateEngineAsync(EngineType.SpeakerEmbedding, stoppingToken).ConfigureAwait(false);
 
         // Warm up all STT engines with a dummy inference to eliminate first-request latency


### PR DESCRIPTION
## Summary

- add `VadPipeline` and `WakeWordPipeline` feature flags
- disable both pipelines in AgentHost configuration
- skip engine registration and startup model activation while disabled

## Validation

- Wyoming project builds successfully
- provider-free unit tests pass