### PR TITLE
fix(command-routing): restore parsed command fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The name is pronounced **LOO-sha** (or **LOO-thee-ah** in traditional Nordic pro
 - **📅 Scheduled Task System** — Extensible CRON-based scheduler with MongoDB persistence supporting alarms, timers, and deferred agent actions
 - **🔌 Extensible** — Script-based plugin system for adding capabilities without recompiling. Plugin repository for discovery and one-click install.
 - **🛠️ Runtime Agent Builder** — Create custom agents via the dashboard with MCP tool integration—no code required
-- **🔌 Model Provider System** — Configure 6+ LLM backends (OpenAI, Azure OpenAI, Azure AI Inference, Ollama, Anthropic, Google Gemini) from the dashboard with per-agent model assignment
+- **🔌 Model Provider System** — Configure OpenAI, llama.cpp, OpenRouter, Azure OpenAI, Azure AI Inference, Ollama, Anthropic, and Google Gemini from the dashboard with per-agent model assignment
 - **🧭 General Knowledge Fallback** — Built-in `general-assistant` handles open-ended requests when no specialist is a clean match
 - **🎭 Dynamic Agent Selection** — Switch between specialized agents (light control, climate, scenes, music, timers, lists, etc.) without reconfiguring
 - **💬 Conversation Threading** — Context-aware conversations with proper message threading support
@@ -47,6 +47,7 @@ The name is pronounced **LOO-sha** (or **LOO-thee-ah** in traditional Nordic pro
 |----------|--------|
 | Azure OpenAI / AI Foundry | ✅ Supported |
 | OpenAI | ✅ Supported |
+| llama.cpp | ✅ Supported |
 | Ollama | ✅ Supported |
 | Anthropic (Claude) | ✅ Supported |
 | Google Gemini | ✅ Supported |
@@ -936,7 +937,7 @@ The Aspire Dashboard provides built-in log aggregation, trace visualization, and
 - Per-agent error rate metrics and observability
 - Two-tier prompt caching (routing + chat) with semantic similarity and hot-reloadable thresholds
 - Helm charts and Kubernetes manifests
-- Multi-LLM support (Azure AI Foundry, OpenAI, Ollama, Anthropic, Google Gemini, Azure AI Inference)
+- Multi-LLM support (Azure AI Foundry, OpenAI, llama.cpp, OpenRouter, Ollama, Anthropic, Google Gemini, Azure AI Inference)
 - Dataset export for fine-tuning workflows
 - Schema-driven configuration system
 - Playwright E2E tests for all agent routing modes

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -75,7 +75,7 @@ Integration tests verify components with real infrastructure (Redis, MongoDB) us
 | Test File | Infrastructure | What's Tested |
 |-----------|---------------|---------------|
 | `Services/RedisTaskStoreTests.cs` | Redis (Testcontainers) | Task CRUD, TTL expiry, key scanning |
-| `Services/ModelProviderResolverTests.cs` | None (mocked providers) | Provider creation for all 7 types, OpenTelemetry wrapping |
+| `Services/ModelProviderResolverTests.cs` | None (mocked providers) | Provider client creation and OpenTelemetry wrapping |
 | `Integration/DurableTaskPersistenceTests.cs` | Redis | Task durability across restarts |
 | `Integration/ExtractDeviceIdTests.cs` | None | Device ID extraction from HA entities |
 

--- a/lucia-dashboard/src/pages/ModelProvidersPage.tsx
+++ b/lucia-dashboard/src/pages/ModelProvidersPage.tsx
@@ -170,6 +170,10 @@ export default function ModelProvidersPage() {
   const handleSave = async () => {
     try {
       setError(null)
+      if (form.providerType === 'LlamaCpp' && !form.endpoint?.trim()) {
+        setError('llama.cpp requires an endpoint URL')
+        return
+      }
 
       // For Copilot providers, store the selected model metadata
       if (form.providerType === 'GitHubCopilot' && selectedCopilotModel) {
@@ -428,6 +432,8 @@ export default function ModelProvidersPage() {
                   // Reset Copilot-specific fields when switching away
                   ...(newType === 'GitHubCopilot'
                     ? { auth: { authType: 'api-key', apiKey: '', useDefaultCredentials: false }, endpoint: '', modelName: '' }
+                    : newType === 'LlamaCpp'
+                      ? { auth: { authType: 'none', apiKey: '', useDefaultCredentials: false } }
                     : {}),
                 }))
                 if (newType !== 'GitHubCopilot') resetCopilotState()
@@ -568,6 +574,7 @@ export default function ModelProvidersPage() {
                 <label className="mb-1 block text-sm text-fog">
                   Endpoint URL
                   {form.providerType === 'Ollama' && <span className="text-dust"> (default: http://localhost:11434)</span>}
+                  {form.providerType === 'LlamaCpp' && <span className="text-dust"> (required)</span>}
                 </label>
                 <input
                   type="text"
@@ -664,7 +671,9 @@ export default function ModelProvidersPage() {
                       : form.providerType === 'OpenRouter'
                         ? 'e.g. openai/gpt-4.1-mini or use Load models'
                         : form.providerType === 'LlamaCpp'
-                          ? 'e.g. embed-qwen3 or use Load models'
+                          ? form.purpose === 'Embedding'
+                            ? 'e.g. embed-qwen3 or use Load models'
+                            : 'e.g. qwen3.5-9b or use Load models'
                         : form.providerType === 'OpenAI'
                           ? 'e.g. gpt-4o or use Load models'
                           : form.providerType === 'GoogleGemini'
@@ -738,7 +747,10 @@ export default function ModelProvidersPage() {
           <div className="flex gap-3 pt-2">
             <button
               onClick={handleSave}
-              disabled={form.providerType === 'GitHubCopilot' && !selectedCopilotModel && mode === 'create'}
+              disabled={
+                (form.providerType === 'GitHubCopilot' && !selectedCopilotModel && mode === 'create') ||
+                (form.providerType === 'LlamaCpp' && !form.endpoint?.trim())
+              }
               className="rounded bg-amber px-4 py-2 text-sm font-medium text-on-accent hover:bg-amber-glow disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {mode === 'create' ? 'Create Provider' : 'Save Changes'}

--- a/lucia-dashboard/src/pages/ModelProvidersPage.tsx
+++ b/lucia-dashboard/src/pages/ModelProvidersPage.tsx
@@ -444,9 +444,7 @@ export default function ModelProvidersPage() {
                   setOllamaModels([])
                   setOllamaError(null)
                 }
-                if (!supportsOpenAiCompatibleModelDiscovery(newType)) {
-                  resetOpenAiModelDiscovery()
-                }
+                resetOpenAiModelDiscovery()
               }}
               className="w-full"
             />

--- a/lucia-dashboard/src/pages/ModelProvidersPage.tsx
+++ b/lucia-dashboard/src/pages/ModelProvidersPage.tsx
@@ -21,6 +21,7 @@ type FormMode = 'list' | 'create' | 'edit'
 const PROVIDER_TYPES: { value: ProviderType; label: string; hint: string }[] = [
   { value: 'OpenAI', label: 'OpenAI', hint: 'OpenAI API (default endpoint: https://api.openai.com/v1)' },
   { value: 'OpenRouter', label: 'OpenRouter', hint: 'OpenRouter API (recommended endpoint: https://openrouter.ai/api/v1)' },
+  { value: 'LlamaCpp', label: 'llama.cpp', hint: 'Local llama.cpp server (for example: http://localhost:8080)' },
   { value: 'AzureOpenAI', label: 'Azure OpenAI', hint: 'Azure-hosted OpenAI deployments' },
   { value: 'AzureAIInference', label: 'Azure AI Inference', hint: 'Azure AI model inference endpoint' },
   { value: 'Ollama', label: 'Ollama', hint: 'Local Ollama instance (default: http://localhost:11434)' },
@@ -37,7 +38,7 @@ const AUTH_TYPES = [
 ]
 
 function supportsOpenAiCompatibleModelDiscovery(providerType: ProviderType): boolean {
-  return providerType === 'OpenAI' || providerType === 'OpenRouter' || providerType === 'GoogleGemini'
+  return providerType === 'OpenAI' || providerType === 'OpenRouter' || providerType === 'LlamaCpp' || providerType === 'GoogleGemini'
 }
 
 function supportsModelDiscovery(providerType: ProviderType): boolean {
@@ -290,10 +291,11 @@ export default function ModelProvidersPage() {
   const handleLoadOpenAiModels = async () => {
     const auth = form.auth ?? { authType: 'api-key', apiKey: '', useDefaultCredentials: false }
     const endpoint = (form.endpoint ?? '').trim()
-    const providerType: ProviderType = form.providerType === 'OpenRouter'
-      ? 'OpenRouter'
-      : form.providerType === 'GoogleGemini'
-        ? 'GoogleGemini'
+    const providerType: ProviderType =
+      form.providerType === 'OpenRouter' ||
+      form.providerType === 'LlamaCpp' ||
+      form.providerType === 'GoogleGemini'
+        ? form.providerType
         : 'OpenAI'
 
     setOpenAiLoading(true)
@@ -576,6 +578,8 @@ export default function ModelProvidersPage() {
                       ? 'http://localhost:11434'
                       : form.providerType === 'OpenRouter'
                         ? 'https://openrouter.ai/api/v1'
+                        : form.providerType === 'LlamaCpp'
+                          ? 'http://localhost:8080'
                         : form.providerType === 'OpenAI'
                           ? 'Leave blank for api.openai.com, or set custom OpenAI-compatible endpoint'
                           : form.providerType === 'GoogleGemini'
@@ -659,6 +663,8 @@ export default function ModelProvidersPage() {
                       ? 'e.g. llama3.1:8b or use Load models'
                       : form.providerType === 'OpenRouter'
                         ? 'e.g. openai/gpt-4.1-mini or use Load models'
+                        : form.providerType === 'LlamaCpp'
+                          ? 'e.g. embed-qwen3 or use Load models'
                         : form.providerType === 'OpenAI'
                           ? 'e.g. gpt-4o or use Load models'
                           : form.providerType === 'GoogleGemini'

--- a/lucia-dashboard/src/pages/ModelProvidersPage.tsx
+++ b/lucia-dashboard/src/pages/ModelProvidersPage.tsx
@@ -426,15 +426,18 @@ export default function ModelProvidersPage() {
               value={form.providerType ?? 'OpenAI'}
               onChange={value => {
                 const newType = value as ProviderType
+                const usesNoAuthByDefault = newType === 'Ollama' || newType === 'LlamaCpp'
                 setForm(prev => ({
                   ...prev,
                   providerType: newType,
-                  // Reset Copilot-specific fields when switching away
-                  ...(newType === 'GitHubCopilot'
-                    ? { auth: { authType: 'api-key', apiKey: '', useDefaultCredentials: false }, endpoint: '', modelName: '' }
-                    : newType === 'LlamaCpp'
-                      ? { auth: { authType: 'none', apiKey: '', useDefaultCredentials: false } }
-                    : {}),
+                  endpoint: '',
+                  modelName: '',
+                  copilotMetadata: undefined,
+                  auth: {
+                    authType: usesNoAuthByDefault ? 'none' : 'api-key',
+                    apiKey: '',
+                    useDefaultCredentials: false,
+                  },
                 }))
                 if (newType !== 'GitHubCopilot') resetCopilotState()
                 if (newType !== 'Ollama') {

--- a/lucia-dashboard/src/pages/SetupPage.tsx
+++ b/lucia-dashboard/src/pages/SetupPage.tsx
@@ -736,6 +736,7 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
               onChange={value => {
                 setProviderType(value as ProviderType)
                 setEndpoint('')
+                setApiKey('')
                 setUseDefaultCreds(false)
               }}
               className="w-full"

--- a/lucia-dashboard/src/pages/SetupPage.tsx
+++ b/lucia-dashboard/src/pages/SetupPage.tsx
@@ -470,6 +470,7 @@ function LuciaHaStep({
 const PROVIDER_TYPES: { value: ProviderType; label: string; placeholder: string }[] = [
   { value: 'OpenAI', label: 'OpenAI', placeholder: 'gpt-4o' },
   { value: 'OpenRouter', label: 'OpenRouter', placeholder: 'openai/gpt-4.1-mini' },
+  { value: 'LlamaCpp', label: 'llama.cpp (local)', placeholder: 'qwen3.5-9b' },
   { value: 'Anthropic', label: 'Anthropic', placeholder: 'claude-sonnet-4-20250514' },
   { value: 'GoogleGemini', label: 'Google Gemini', placeholder: 'gemini-2.0-flash' },
   { value: 'Ollama', label: 'Ollama (local)', placeholder: 'llama3.2:3b' },
@@ -511,7 +512,9 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
   useEffect(() => { refreshProviders() }, [refreshProviders])
 
   const isAzure = providerType === 'AzureOpenAI' || providerType === 'AzureAIInference'
-  const needsApiKey = providerType !== 'Ollama' && !useDefaultCreds
+  const isLlamaCpp = providerType === 'LlamaCpp'
+  const needsEndpoint = isAzure || isLlamaCpp
+  const needsApiKey = providerType !== 'Ollama' && !isLlamaCpp && !useDefaultCreds
   const hasChatProvider = providers.some(p => p.purpose === 'Chat' && Boolean(p.modelName?.trim()))
 
   async function handleCreate() {
@@ -523,7 +526,7 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
       const providerLabel = PROVIDER_TYPES.find(p => p.value === providerType)?.label ?? providerType
       const auth: ModelAuthConfig = useDefaultCreds
         ? { authType: 'default-credential', useDefaultCredentials: true }
-        : needsApiKey
+        : needsApiKey || Boolean(apiKey.trim())
           ? { authType: 'api-key', apiKey, useDefaultCredentials: false }
           : { authType: 'none', useDefaultCredentials: false }
 
@@ -750,7 +753,9 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
               Endpoint URL
               {isAzure
                 ? <span className="text-dust"> (required — your Azure OpenAI resource URL)</span>
-                : <span className="text-dust"> (optional{providerType === 'Ollama' ? ', default: http://localhost:11434' : ''})</span>
+                : isLlamaCpp
+                  ? <span className="text-dust"> (required)</span>
+                  : <span className="text-dust"> (optional{providerType === 'Ollama' ? ', default: http://localhost:11434' : ''})</span>
               }
             </label>
             <input
@@ -764,6 +769,8 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
                     ? 'http://localhost:11434'
                     : providerType === 'OpenRouter'
                       ? 'https://openrouter.ai/api/v1'
+                      : isLlamaCpp
+                        ? 'http://localhost:8080'
                       : 'Leave blank for default'
               }
               className={inputStyle}
@@ -786,9 +793,11 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
           )}
 
           {/* API Key */}
-          {needsApiKey && (
+          {(needsApiKey || isLlamaCpp) && (
             <div>
-              <label className="mb-1 block text-sm text-fog">API Key</label>
+              <label className="mb-1 block text-sm text-fog">
+                API Key{isLlamaCpp && <span className="text-dust"> (optional)</span>}
+              </label>
               <input
                 type="password"
                 value={apiKey}
@@ -802,7 +811,7 @@ function AiProviderStep({ onComplete }: { onComplete: () => void }) {
           <div className="flex gap-2 pt-1">
             <button
               onClick={handleCreate}
-              disabled={busy || (needsApiKey && !apiKey) || (isAzure && !endpoint)}
+              disabled={busy || (needsApiKey && !apiKey) || (needsEndpoint && !endpoint.trim())}
               className={btnPrimary}
             >
               {busy ? 'Saving...' : 'Save Connection'}

--- a/lucia-dashboard/src/types.ts
+++ b/lucia-dashboard/src/types.ts
@@ -244,13 +244,13 @@ export interface AgentDefinition {
 
 // Model Providers
 /** LLM provider type identifier. */
-export type ProviderType = 'OpenAI' | 'OpenRouter' | 'AzureOpenAI' | 'AzureAIInference' | 'Ollama' | 'Anthropic' | 'GoogleGemini' | 'GitHubCopilot';
+export type ProviderType = 'OpenAI' | 'OpenRouter' | 'LlamaCpp' | 'AzureOpenAI' | 'AzureAIInference' | 'Ollama' | 'Anthropic' | 'GoogleGemini' | 'GitHubCopilot';
 
 /** Whether a provider is configured for chat completion or embedding generation. */
 export type ModelPurpose = 'Chat' | 'Embedding';
 
 /** Provider types that support embedding generation. */
-export const EmbeddingCapableProviders: ProviderType[] = ['OpenAI', 'OpenRouter', 'AzureOpenAI', 'AzureAIInference', 'Ollama', 'GoogleGemini'];
+export const EmbeddingCapableProviders: ProviderType[] = ['OpenAI', 'OpenRouter', 'LlamaCpp', 'AzureOpenAI', 'AzureAIInference', 'Ollama', 'GoogleGemini'];
 
 export interface ModelAuthConfig {
   authType: string;

--- a/lucia.AgentHost/Apis/ModelProviderApi.cs
+++ b/lucia.AgentHost/Apis/ModelProviderApi.cs
@@ -6,6 +6,7 @@ using lucia.Agents.Configuration.UserConfiguration;
 using lucia.Agents.GitHubCopilot;
 using lucia.Agents.GitHubCopilot.Models;
 using lucia.Agents.Models;
+using lucia.Agents.Providers;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -94,6 +95,10 @@ public static class ModelProviderApi
         if (string.IsNullOrWhiteSpace(provider.Name))
             return TypedResults.BadRequest("Provider name is required");
 
+        var validationError = ValidateProvider(provider);
+        if (validationError is not null)
+            return TypedResults.BadRequest(validationError);
+
         var existing = await repository.GetProviderAsync(provider.Id, ct).ConfigureAwait(false);
         if (existing is not null)
             return TypedResults.BadRequest($"Provider with id '{provider.Id}' already exists");
@@ -107,7 +112,7 @@ public static class ModelProviderApi
         return TypedResults.Created($"/api/model-providers/{provider.Id}", provider);
     }
 
-    private static async Task<Results<Ok<ModelProvider>, NotFound>> UpdateProviderAsync(
+    private static async Task<Results<Ok<ModelProvider>, NotFound, BadRequest<string>>> UpdateProviderAsync(
         string id,
         [FromBody] ModelProvider provider,
         [FromServices] IModelProviderRepository repository,
@@ -117,6 +122,10 @@ public static class ModelProviderApi
         if (existing is null)
             return TypedResults.NotFound();
 
+        var validationError = ValidateProvider(provider);
+        if (validationError is not null)
+            return TypedResults.BadRequest(validationError);
+
         provider.Id = id;
         provider.CreatedAt = existing.CreatedAt;
         provider.UpdatedAt = DateTime.UtcNow;
@@ -124,6 +133,12 @@ public static class ModelProviderApi
         await repository.UpsertProviderAsync(provider, ct).ConfigureAwait(false);
         return TypedResults.Ok(provider);
     }
+
+    private static string? ValidateProvider(ModelProvider provider) =>
+        provider.ProviderType == ProviderType.LlamaCpp
+            && !LlamaCppEndpoint.TryNormalize(provider.Endpoint, out _)
+                ? "llama.cpp provider requires a valid HTTP or HTTPS endpoint URL"
+                : null;
 
     private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> DeleteProviderAsync(
         string id,

--- a/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
+++ b/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
@@ -190,10 +190,11 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         var captures = route.CapturedValues ?? new Dictionary<string, string>();
 
         if (!captures.TryGetValue("value", out var tempStr) ||
-            !double.TryParse(tempStr, CultureInfo.InvariantCulture, out var temperature))
+            !double.TryParse(tempStr, CultureInfo.InvariantCulture, out var temperature) ||
+            !double.IsFinite(temperature))
         {
             throw new InvalidOperationException(
-                "Temperature value not captured or not a valid number");
+                "Temperature value not captured or not a finite number");
         }
 
         var entityId = useCascadingResolver
@@ -295,10 +296,9 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
                 ResolveEntitySearchQuery(route),
                 options: matchOptions,
                 domainFilter: domains,
+                callerAgentId: callerAgentId,
                 ct: ct).ConfigureAwait(false);
             resolvedIds = fuzzyResult.ResolvedEntities
-                .Where(entity => entity.IncludeForAgent is null
-                    || (callerAgentId is not null && entity.IncludeForAgent.Contains(callerAgentId)))
                 .Select(entity => entity.EntityId)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();

--- a/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
+++ b/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
@@ -20,9 +20,8 @@ namespace lucia.AgentHost.Conversation.Execution;
 
 /// <summary>
 /// Executes matched command routes by calling skill methods directly, bypassing LLM processing.
-/// Entity resolution uses exact-match lookups against the in-memory cache only.
-/// If the cache is not loaded or no exact match is found, execution bails immediately
-/// so the orchestrator can handle the request via LLM.
+/// Entity resolution starts with deterministic cache matching and retries no-match results
+/// through the configured embedding matcher before deferring to LLM orchestration.
 /// </summary>
 public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
 {

--- a/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
+++ b/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
@@ -165,10 +165,11 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         var captures = route.CapturedValues ?? new Dictionary<string, string>();
 
         if (!captures.TryGetValue("value", out var valueStr) ||
-            !int.TryParse(valueStr, CultureInfo.InvariantCulture, out var brightness))
+            !int.TryParse(valueStr, CultureInfo.InvariantCulture, out var brightness) ||
+            brightness is < 0 or > 100)
         {
             throw new InvalidOperationException(
-                "Brightness value not captured or not a valid integer");
+                "Brightness value must be an integer between 0 and 100");
         }
 
         var resolvedIds = useCascadingResolver
@@ -194,7 +195,7 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
             !double.IsFinite(temperature))
         {
             throw new InvalidOperationException(
-                "Temperature value not captured or not a finite number");
+                "Temperature value was not captured or is not a valid finite number");
         }
 
         var entityId = useCascadingResolver

--- a/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
+++ b/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
@@ -148,7 +148,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
 
         var state = captures.GetValueOrDefault("action", "on");
         var resolvedIds = useCascadingResolver
-            ? await ResolveEntitiesWithCascadeAsync(route, context, LightDomains, requireSingle: false, "light-agent", ct)
+            ? await ResolveEntitiesWithCascadeAsync(
+                route, context, LightDomains, skill.GetCurrentMatchOptions(), requireSingle: false, "light-agent", ct)
                 .ConfigureAwait(false)
             : ResolveSearchTermsToEntityIds(BuildSearchTerms(route, context), LightDomains);
 
@@ -172,7 +173,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         }
 
         var resolvedIds = useCascadingResolver
-            ? await ResolveEntitiesWithCascadeAsync(route, context, LightDomains, requireSingle: false, "light-agent", ct)
+            ? await ResolveEntitiesWithCascadeAsync(
+                route, context, LightDomains, skill.GetCurrentMatchOptions(), requireSingle: false, "light-agent", ct)
                 .ConfigureAwait(false)
             : ResolveSearchTermsToEntityIds(BuildSearchTerms(route, context), LightDomains);
 
@@ -196,7 +198,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         }
 
         var entityId = useCascadingResolver
-            ? await ResolveSingleEntityWithCascadeAsync(route, context, ClimateDomains, "climate-agent", ct)
+            ? await ResolveSingleEntityWithCascadeAsync(
+                route, context, ClimateDomains, skill.GetCurrentMatchOptions(), "climate-agent", ct)
                 .ConfigureAwait(false)
             : ResolveEntityIdFromCache(route, ClimateDomains);
 
@@ -214,7 +217,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
 
         var direction = captures.GetValueOrDefault("action", "warmer");
         var entityId = useCascadingResolver
-            ? await ResolveSingleEntityWithCascadeAsync(route, context, ClimateDomains, "climate-agent", ct)
+            ? await ResolveSingleEntityWithCascadeAsync(
+                route, context, ClimateDomains, skill.GetCurrentMatchOptions(), "climate-agent", ct)
                 .ConfigureAwait(false)
             : ResolveEntityIdFromCache(route, ClimateDomains);
 
@@ -254,7 +258,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
     {
         var skill = _serviceProvider.GetRequiredService<SceneControlSkill>();
         var entityId = useCascadingResolver
-            ? await ResolveSingleEntityWithCascadeAsync(route, context, SceneDomains, "scene-agent", ct)
+            ? await ResolveSingleEntityWithCascadeAsync(
+                route, context, SceneDomains, skill.GetCurrentMatchOptions(), "scene-agent", ct)
                 .ConfigureAwait(false)
             : ResolveEntityIdFromCache(route, SceneDomains, captureKey: "scene");
 
@@ -270,6 +275,7 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         CommandRouteResult route,
         ConversationContext context,
         IReadOnlyList<string> domains,
+        HybridMatchOptions matchOptions,
         bool requireSingle,
         string? callerAgentId,
         CancellationToken ct)
@@ -288,6 +294,7 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         {
             var fuzzyResult = await _entityLocationService.SearchHierarchyAsync(
                 ResolveEntitySearchQuery(route),
+                options: matchOptions,
                 domainFilter: domains,
                 ct: ct).ConfigureAwait(false);
             resolvedIds = fuzzyResult.ResolvedEntities
@@ -319,11 +326,12 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         CommandRouteResult route,
         ConversationContext context,
         IReadOnlyList<string> domains,
+        HybridMatchOptions matchOptions,
         string? callerAgentId,
         CancellationToken ct)
     {
         var resolvedIds = await ResolveEntitiesWithCascadeAsync(
-            route, context, domains, requireSingle: true, callerAgentId, ct).ConfigureAwait(false);
+            route, context, domains, matchOptions, requireSingle: true, callerAgentId, ct).ConfigureAwait(false);
         return resolvedIds[0];
     }
 

--- a/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
+++ b/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
@@ -148,7 +148,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
 
         var state = captures.GetValueOrDefault("action", "on");
         var resolvedIds = useCascadingResolver
-            ? ResolveEntitiesWithCascade(route, context, LightDomains, requireSingle: false, "light-agent", ct)
+            ? await ResolveEntitiesWithCascadeAsync(route, context, LightDomains, requireSingle: false, "light-agent", ct)
+                .ConfigureAwait(false)
             : ResolveSearchTermsToEntityIds(BuildSearchTerms(route, context), LightDomains);
 
         return await collector.RecordAsync(
@@ -171,7 +172,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         }
 
         var resolvedIds = useCascadingResolver
-            ? ResolveEntitiesWithCascade(route, context, LightDomains, requireSingle: false, "light-agent", ct)
+            ? await ResolveEntitiesWithCascadeAsync(route, context, LightDomains, requireSingle: false, "light-agent", ct)
+                .ConfigureAwait(false)
             : ResolveSearchTermsToEntityIds(BuildSearchTerms(route, context), LightDomains);
 
         return await collector.RecordAsync(
@@ -194,7 +196,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         }
 
         var entityId = useCascadingResolver
-            ? ResolveSingleEntityWithCascade(route, context, ClimateDomains, "climate-agent", ct)
+            ? await ResolveSingleEntityWithCascadeAsync(route, context, ClimateDomains, "climate-agent", ct)
+                .ConfigureAwait(false)
             : ResolveEntityIdFromCache(route, ClimateDomains);
 
         return await collector.RecordAsync(
@@ -211,7 +214,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
 
         var direction = captures.GetValueOrDefault("action", "warmer");
         var entityId = useCascadingResolver
-            ? ResolveSingleEntityWithCascade(route, context, ClimateDomains, "climate-agent", ct)
+            ? await ResolveSingleEntityWithCascadeAsync(route, context, ClimateDomains, "climate-agent", ct)
+                .ConfigureAwait(false)
             : ResolveEntityIdFromCache(route, ClimateDomains);
 
         var stateInfo = await collector.RecordAsync(
@@ -250,7 +254,8 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
     {
         var skill = _serviceProvider.GetRequiredService<SceneControlSkill>();
         var entityId = useCascadingResolver
-            ? ResolveSingleEntityWithCascade(route, context, SceneDomains, "scene-agent", ct)
+            ? await ResolveSingleEntityWithCascadeAsync(route, context, SceneDomains, "scene-agent", ct)
+                .ConfigureAwait(false)
             : ResolveEntityIdFromCache(route, SceneDomains, captureKey: "scene");
 
         return await collector.RecordAsync(
@@ -261,7 +266,7 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
 
     // ── Entity resolution helpers ────────────────────────────────────
 
-    private string[] ResolveEntitiesWithCascade(
+    private async Task<string[]> ResolveEntitiesWithCascadeAsync(
         CommandRouteResult route,
         ConversationContext context,
         IReadOnlyList<string> domains,
@@ -278,39 +283,71 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
             callerAgentId,
             ct);
 
-        if (!result.IsResolved)
+        var resolvedIds = result.ResolvedEntityIds;
+        if (!result.IsResolved && result.BailReason == BailReason.NoMatch)
+        {
+            var fuzzyResult = await _entityLocationService.SearchHierarchyAsync(
+                ResolveEntitySearchQuery(route),
+                domainFilter: domains,
+                ct: ct).ConfigureAwait(false);
+            resolvedIds = fuzzyResult.ResolvedEntities
+                .Where(entity => entity.IncludeForAgent is null
+                    || (callerAgentId is not null && entity.IncludeForAgent.Contains(callerAgentId)))
+                .Select(entity => entity.EntityId)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        if (resolvedIds.Count == 0)
         {
             var reason = result.BailReason?.ToString() ?? "cascade_bail";
             var explanation = result.Explanation ?? "Cascading resolver bailed; deferring to orchestrator";
             throw new EntityResolutionBailException(reason, explanation);
         }
 
-        if (result.ResolvedEntityIds.Count == 0)
-        {
-            throw new EntityResolutionBailException(
-                BailReason.NoMatch.ToString(),
-                "Cascading resolver returned no entity IDs");
-        }
-
-        if (requireSingle && result.ResolvedEntityIds.Count != 1)
+        if (requireSingle && resolvedIds.Count != 1)
         {
             throw new EntityResolutionBailException(
                 BailReason.Ambiguous.ToString(),
                 "Multiple entities resolved for single-target command");
         }
 
-        return result.ResolvedEntityIds.ToArray();
+        return resolvedIds.ToArray();
     }
 
-    private string ResolveSingleEntityWithCascade(
+    private async Task<string> ResolveSingleEntityWithCascadeAsync(
         CommandRouteResult route,
         ConversationContext context,
         IReadOnlyList<string> domains,
         string? callerAgentId,
         CancellationToken ct)
     {
-        var resolvedIds = ResolveEntitiesWithCascade(route, context, domains, requireSingle: true, callerAgentId, ct);
+        var resolvedIds = await ResolveEntitiesWithCascadeAsync(
+            route, context, domains, requireSingle: true, callerAgentId, ct).ConfigureAwait(false);
         return resolvedIds[0];
+    }
+
+    private static string ResolveEntitySearchQuery(CommandRouteResult route)
+    {
+        if (route.CapturedValues?.TryGetValue("entity", out var entity) == true
+            && !string.IsNullOrWhiteSpace(entity))
+        {
+            return entity;
+        }
+
+        if (route.CapturedValues?.TryGetValue("scene", out var scene) == true
+            && !string.IsNullOrWhiteSpace(scene))
+        {
+            return scene;
+        }
+
+        if (route.CapturedValues?.TryGetValue("area", out var area) == true
+            && !string.IsNullOrWhiteSpace(area))
+        {
+            return area;
+        }
+
+        return route.NormalizedTranscript ?? route.MatchedTemplate ?? string.Empty;
     }
 
     private static string ResolveCascadeQuery(CommandRouteResult route)

--- a/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
+++ b/lucia.AgentHost/Conversation/Execution/DirectSkillExecutor.cs
@@ -293,11 +293,19 @@ public sealed partial class DirectSkillExecutor : IDirectSkillExecutor
         var resolvedIds = result.ResolvedEntityIds;
         if (!result.IsResolved && result.BailReason == BailReason.NoMatch)
         {
-            var fuzzyResult = await _entityLocationService.SearchHierarchyAsync(
+            if (_entityLocationService is not IAgentFilteredEntityLocationService filteredLocationService
+                || callerAgentId is null)
+            {
+                throw new EntityResolutionBailException(
+                    result.BailReason.Value.ToString(),
+                    result.Explanation ?? "Agent-filtered entity search is unavailable");
+            }
+
+            var fuzzyResult = await filteredLocationService.SearchHierarchyForAgentAsync(
                 ResolveEntitySearchQuery(route),
                 options: matchOptions,
                 domainFilter: domains,
-                callerAgentId: callerAgentId,
+                callerAgentId,
                 ct: ct).ConfigureAwait(false);
             resolvedIds = fuzzyResult.ResolvedEntities
                 .Select(entity => entity.EntityId)

--- a/lucia.AgentHost/Services/ProviderModelCatalogService.cs
+++ b/lucia.AgentHost/Services/ProviderModelCatalogService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using lucia.AgentHost.Models;
 using lucia.Agents.Configuration;
 using lucia.Agents.Configuration.UserConfiguration;
+using lucia.Agents.Providers;
 
 namespace lucia.AgentHost.Services;
 
@@ -44,7 +45,13 @@ public sealed class ProviderModelCatalogService
             ProviderType.Ollama => await ListOllamaModelsAsync(endpoint, ct).ConfigureAwait(false),
             ProviderType.OpenAI => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, DefaultOpenAiEndpoint, ct).ConfigureAwait(false),
             ProviderType.OpenRouter => await ListOpenRouterModelsAsync(endpoint, auth?.ApiKey, ct).ConfigureAwait(false),
-            ProviderType.LlamaCpp => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, string.Empty, ct).ConfigureAwait(false),
+            ProviderType.LlamaCpp => string.IsNullOrWhiteSpace(endpoint)
+                ? new ProviderModelsResponse { Error = "llama.cpp provider requires an endpoint URL." }
+                : await ListOpenAiCompatibleModelsAsync(
+                    LlamaCppEndpoint.Normalize(endpoint).ToString(),
+                    auth?.ApiKey,
+                    string.Empty,
+                    ct).ConfigureAwait(false),
             ProviderType.GoogleGemini => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, DefaultGeminiEndpoint, ct).ConfigureAwait(false),
             _ => new ProviderModelsResponse
             {

--- a/lucia.AgentHost/Services/ProviderModelCatalogService.cs
+++ b/lucia.AgentHost/Services/ProviderModelCatalogService.cs
@@ -44,6 +44,7 @@ public sealed class ProviderModelCatalogService
             ProviderType.Ollama => await ListOllamaModelsAsync(endpoint, ct).ConfigureAwait(false),
             ProviderType.OpenAI => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, DefaultOpenAiEndpoint, ct).ConfigureAwait(false),
             ProviderType.OpenRouter => await ListOpenRouterModelsAsync(endpoint, auth?.ApiKey, ct).ConfigureAwait(false),
+            ProviderType.LlamaCpp => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, string.Empty, ct).ConfigureAwait(false),
             ProviderType.GoogleGemini => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, DefaultGeminiEndpoint, ct).ConfigureAwait(false),
             _ => new ProviderModelsResponse
             {

--- a/lucia.AgentHost/Services/ProviderModelCatalogService.cs
+++ b/lucia.AgentHost/Services/ProviderModelCatalogService.cs
@@ -45,13 +45,7 @@ public sealed class ProviderModelCatalogService
             ProviderType.Ollama => await ListOllamaModelsAsync(endpoint, ct).ConfigureAwait(false),
             ProviderType.OpenAI => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, DefaultOpenAiEndpoint, ct).ConfigureAwait(false),
             ProviderType.OpenRouter => await ListOpenRouterModelsAsync(endpoint, auth?.ApiKey, ct).ConfigureAwait(false),
-            ProviderType.LlamaCpp => string.IsNullOrWhiteSpace(endpoint)
-                ? new ProviderModelsResponse { Error = "llama.cpp provider requires an endpoint URL." }
-                : await ListOpenAiCompatibleModelsAsync(
-                    LlamaCppEndpoint.Normalize(endpoint).ToString(),
-                    auth?.ApiKey,
-                    string.Empty,
-                    ct).ConfigureAwait(false),
+            ProviderType.LlamaCpp => await ListLlamaCppModelsAsync(endpoint, auth?.ApiKey, ct).ConfigureAwait(false),
             ProviderType.GoogleGemini => await ListOpenAiCompatibleModelsAsync(endpoint, auth?.ApiKey, DefaultGeminiEndpoint, ct).ConfigureAwait(false),
             _ => new ProviderModelsResponse
             {
@@ -102,6 +96,24 @@ public sealed class ProviderModelCatalogService
         }
 
         return result;
+    }
+
+    private async Task<ProviderModelsResponse> ListLlamaCppModelsAsync(
+        string? endpoint,
+        string? apiKey,
+        CancellationToken ct)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return new ProviderModelsResponse { Error = "Invalid llama.cpp endpoint URL" };
+        }
+
+        return await ListOpenAiCompatibleModelsAsync(
+            LlamaCppEndpoint.Normalize(uri.ToString()).ToString(),
+            apiKey,
+            string.Empty,
+            ct).ConfigureAwait(false);
     }
 
     private async Task<ProviderModelsResponse> ListOpenRouterModelsAsync(

--- a/lucia.Agents/Abstractions/IAgentFilteredEntityLocationService.cs
+++ b/lucia.Agents/Abstractions/IAgentFilteredEntityLocationService.cs
@@ -1,0 +1,13 @@
+using lucia.Agents.Models;
+
+namespace lucia.Agents.Abstractions;
+
+public interface IAgentFilteredEntityLocationService
+{
+    Task<HierarchicalSearchResult> SearchHierarchyForAgentAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string callerAgentId,
+        CancellationToken ct = default);
+}

--- a/lucia.Agents/Abstractions/IEntityLocationService.cs
+++ b/lucia.Agents/Abstractions/IEntityLocationService.cs
@@ -98,13 +98,6 @@ public interface IEntityLocationService
         IReadOnlyList<string>? domainFilter = null,
         CancellationToken ct = default);
 
-    Task<HierarchicalSearchResult> SearchHierarchyAsync(
-        string query,
-        HybridMatchOptions? options,
-        IReadOnlyList<string>? domainFilter,
-        string? callerAgentId,
-        CancellationToken ct = default);
-
     /// <summary>
     /// Get the area for an entity (0..1 relationship). Returns null if no area assigned.
     /// Thread-safe: reads from immutable snapshot.

--- a/lucia.Agents/Abstractions/IEntityLocationService.cs
+++ b/lucia.Agents/Abstractions/IEntityLocationService.cs
@@ -98,6 +98,13 @@ public interface IEntityLocationService
         IReadOnlyList<string>? domainFilter = null,
         CancellationToken ct = default);
 
+    Task<HierarchicalSearchResult> SearchHierarchyAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string? callerAgentId,
+        CancellationToken ct = default);
+
     /// <summary>
     /// Get the area for an entity (0..1 relationship). Returns null if no area assigned.
     /// Thread-safe: reads from immutable snapshot.

--- a/lucia.Agents/Configuration/ProviderType.cs
+++ b/lucia.Agents/Configuration/ProviderType.cs
@@ -14,9 +14,6 @@ public enum ProviderType
     /// <summary>OpenRouter API (OpenAI-compatible endpoint with OpenRouter model metadata).</summary>
     OpenRouter,
 
-    /// <summary>llama.cpp server using its OpenAI-compatible API.</summary>
-    LlamaCpp,
-
     /// <summary>Azure OpenAI Service.</summary>
     AzureOpenAI,
 
@@ -33,5 +30,8 @@ public enum ProviderType
     GoogleGemini,
 
     /// <summary>GitHub Copilot SDK (requires copilot CLI installed and authenticated).</summary>
-    GitHubCopilot
+    GitHubCopilot,
+
+    /// <summary>llama.cpp server using its OpenAI-compatible API.</summary>
+    LlamaCpp
 }

--- a/lucia.Agents/Configuration/ProviderType.cs
+++ b/lucia.Agents/Configuration/ProviderType.cs
@@ -14,6 +14,9 @@ public enum ProviderType
     /// <summary>OpenRouter API (OpenAI-compatible endpoint with OpenRouter model metadata).</summary>
     OpenRouter,
 
+    /// <summary>llama.cpp server using its OpenAI-compatible API.</summary>
+    LlamaCpp,
+
     /// <summary>Azure OpenAI Service.</summary>
     AzureOpenAI,
 

--- a/lucia.Agents/Integration/CommandTextNormalizer.cs
+++ b/lucia.Agents/Integration/CommandTextNormalizer.cs
@@ -26,7 +26,7 @@ public static class CommandTextNormalizer
             var isNumericSign = character is '-' or '+'
                 && index < value.Length - 1
                 && char.IsDigit(value[index + 1])
-                && (index == 0 || char.IsWhiteSpace(value[index - 1]));
+                && (result.Length == 0 || char.IsWhiteSpace(result[^1]));
 
             result.Append(isDecimalPoint || isNumericSign ? character : ' ');
         }

--- a/lucia.Agents/Integration/CommandTextNormalizer.cs
+++ b/lucia.Agents/Integration/CommandTextNormalizer.cs
@@ -18,15 +18,20 @@ public static class CommandTextNormalizer
                 continue;
             }
 
+            var isNumericBoundary = result.Length == 0
+                || char.IsWhiteSpace(result[^1])
+                || result[^1] is '-' or '+';
             var isDecimalPoint = character == '.'
-                && index > 0
-                && index < value.Length - 1
-                && char.IsDigit(value[index - 1])
-                && char.IsDigit(value[index + 1]);
-            var isNumericSign = character is '-' or '+'
                 && index < value.Length - 1
                 && char.IsDigit(value[index + 1])
-                && (result.Length == 0 || char.IsWhiteSpace(result[^1]));
+                && ((index > 0 && char.IsDigit(value[index - 1])) || isNumericBoundary);
+            var isNumericSign = character is '-' or '+'
+                && index < value.Length - 1
+                && (char.IsDigit(value[index + 1])
+                    || (value[index + 1] == '.'
+                        && index < value.Length - 2
+                        && char.IsDigit(value[index + 2])))
+                && isNumericBoundary;
 
             result.Append(isDecimalPoint || isNumericSign ? character : ' ');
         }

--- a/lucia.Agents/Integration/CommandTextNormalizer.cs
+++ b/lucia.Agents/Integration/CommandTextNormalizer.cs
@@ -1,0 +1,36 @@
+using System.Text;
+
+namespace lucia.Agents.Integration;
+
+public static class CommandTextNormalizer
+{
+    public static string NormalizePunctuation(string value)
+    {
+        var result = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (char.IsLetterOrDigit(character)
+                || char.IsWhiteSpace(character)
+                || character == '_')
+            {
+                result.Append(character);
+                continue;
+            }
+
+            var isDecimalPoint = character == '.'
+                && index > 0
+                && index < value.Length - 1
+                && char.IsDigit(value[index - 1])
+                && char.IsDigit(value[index + 1]);
+            var isNumericSign = character is '-' or '+'
+                && index < value.Length - 1
+                && char.IsDigit(value[index + 1])
+                && (index == 0 || char.IsWhiteSpace(value[index - 1]));
+
+            result.Append(isDecimalPoint || isNumericSign ? character : ' ');
+        }
+
+        return result.ToString();
+    }
+}

--- a/lucia.Agents/Providers/LlamaCppEndpoint.cs
+++ b/lucia.Agents/Providers/LlamaCppEndpoint.cs
@@ -1,0 +1,17 @@
+namespace lucia.Agents.Providers;
+
+public static class LlamaCppEndpoint
+{
+    public static Uri Normalize(string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+            throw new InvalidOperationException("llama.cpp provider requires an endpoint URL");
+
+        var builder = new UriBuilder(endpoint);
+        var path = builder.Path.TrimEnd('/');
+        if (!path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            builder.Path = $"{path}/v1";
+
+        return builder.Uri;
+    }
+}

--- a/lucia.Agents/Providers/LlamaCppEndpoint.cs
+++ b/lucia.Agents/Providers/LlamaCppEndpoint.cs
@@ -4,14 +4,28 @@ public static class LlamaCppEndpoint
 {
     public static Uri Normalize(string? endpoint)
     {
-        if (string.IsNullOrWhiteSpace(endpoint))
-            throw new InvalidOperationException("llama.cpp provider requires an endpoint URL");
+        if (!TryNormalize(endpoint, out var normalizedEndpoint)
+            || normalizedEndpoint is null)
+            throw new InvalidOperationException("llama.cpp provider requires a valid HTTP or HTTPS endpoint URL");
 
-        var builder = new UriBuilder(endpoint);
+        return normalizedEndpoint;
+    }
+
+    public static bool TryNormalize(string? endpoint, out Uri? normalizedEndpoint)
+    {
+        normalizedEndpoint = null;
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        var builder = new UriBuilder(uri);
         var path = builder.Path.TrimEnd('/');
         if (!path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
             builder.Path = $"{path}/v1";
 
-        return builder.Uri;
+        normalizedEndpoint = builder.Uri;
+        return true;
     }
 }

--- a/lucia.Agents/Providers/LlamaCppEndpoint.cs
+++ b/lucia.Agents/Providers/LlamaCppEndpoint.cs
@@ -22,8 +22,9 @@ public static class LlamaCppEndpoint
 
         var builder = new UriBuilder(uri);
         var path = builder.Path.TrimEnd('/');
-        if (!path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
-            builder.Path = $"{path}/v1";
+        builder.Path = path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
+            ? $"{path[..^3]}/v1"
+            : $"{path}/v1";
 
         normalizedEndpoint = builder.Uri;
         return true;

--- a/lucia.Agents/Providers/ModelProviderResolver.cs
+++ b/lucia.Agents/Providers/ModelProviderResolver.cs
@@ -155,7 +155,7 @@ public sealed class ModelProviderResolver : IModelProviderResolver
     {
         var client = new OpenAIClient(
             new ApiKeyCredential(provider.Auth.ApiKey ?? "unused"),
-            CreateLlamaCppOptions(provider.Endpoint));
+            new OpenAIClientOptions { Endpoint = LlamaCppEndpoint.Normalize(provider.Endpoint) });
         return client.GetChatClient(provider.ModelName).AsIChatClient();
     }
 
@@ -169,19 +169,6 @@ public sealed class ModelProviderResolver : IModelProviderResolver
         }
 
         return options;
-    }
-
-    private static OpenAIClientOptions CreateLlamaCppOptions(string? endpoint)
-    {
-        if (string.IsNullOrWhiteSpace(endpoint))
-            throw new InvalidOperationException("llama.cpp provider requires an endpoint URL");
-
-        var builder = new UriBuilder(endpoint);
-        var path = builder.Path.TrimEnd('/');
-        if (!path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
-            builder.Path = $"{path}/v1";
-
-        return new OpenAIClientOptions { Endpoint = builder.Uri };
     }
 
     private static IChatClient CreateAzureOpenAIClient(ModelProvider provider)
@@ -367,7 +354,7 @@ public sealed class ModelProviderResolver : IModelProviderResolver
     {
         var client = new OpenAIClient(
             new ApiKeyCredential(provider.Auth.ApiKey ?? "unused"),
-            CreateLlamaCppOptions(provider.Endpoint));
+            new OpenAIClientOptions { Endpoint = LlamaCppEndpoint.Normalize(provider.Endpoint) });
         return client.GetEmbeddingClient(provider.ModelName).AsIEmbeddingGenerator()
             .AsBuilder()
             .UseOpenTelemetry(sourceName: "lucia", configure: cfg =>

--- a/lucia.Agents/Providers/ModelProviderResolver.cs
+++ b/lucia.Agents/Providers/ModelProviderResolver.cs
@@ -154,7 +154,7 @@ public sealed class ModelProviderResolver : IModelProviderResolver
     private static IChatClient CreateLlamaCppClient(ModelProvider provider)
     {
         var client = new OpenAIClient(
-            new ApiKeyCredential(provider.Auth.ApiKey ?? "unused"),
+            new ApiKeyCredential(GetLlamaCppApiKey(provider.Auth.ApiKey)),
             new OpenAIClientOptions { Endpoint = LlamaCppEndpoint.Normalize(provider.Endpoint) });
         return client.GetChatClient(provider.ModelName).AsIChatClient();
     }
@@ -353,7 +353,7 @@ public sealed class ModelProviderResolver : IModelProviderResolver
     private static IEmbeddingGenerator<string, Embedding<float>> CreateLlamaCppEmbeddingGenerator(ModelProvider provider)
     {
         var client = new OpenAIClient(
-            new ApiKeyCredential(provider.Auth.ApiKey ?? "unused"),
+            new ApiKeyCredential(GetLlamaCppApiKey(provider.Auth.ApiKey)),
             new OpenAIClientOptions { Endpoint = LlamaCppEndpoint.Normalize(provider.Endpoint) });
         return client.GetEmbeddingClient(provider.ModelName).AsIEmbeddingGenerator()
             .AsBuilder()
@@ -361,6 +361,9 @@ public sealed class ModelProviderResolver : IModelProviderResolver
                 cfg.EnableSensitiveData = true)
             .Build();
     }
+
+    private static string GetLlamaCppApiKey(string? apiKey) =>
+        string.IsNullOrWhiteSpace(apiKey) ? "unused" : apiKey;
 
     private static IEmbeddingGenerator<string, Embedding<float>> CreateAzureOpenAIEmbeddingGenerator(ModelProvider provider)
     {

--- a/lucia.Agents/Providers/ModelProviderResolver.cs
+++ b/lucia.Agents/Providers/ModelProviderResolver.cs
@@ -20,7 +20,7 @@ namespace lucia.Agents.Providers;
 
 /// <summary>
 /// Creates IChatClient and IEmbeddingGenerator instances from stored ModelProvider configurations.
-/// Supports OpenAI, OpenRouter, Azure OpenAI, Azure AI Inference, Ollama, Anthropic, Google Gemini,
+/// Supports OpenAI, OpenRouter, llama.cpp, Azure OpenAI, Azure AI Inference, Ollama, Anthropic, Google Gemini,
 /// and GitHub Copilot SDK.
 /// </summary>
 public sealed class ModelProviderResolver : IModelProviderResolver
@@ -50,6 +50,7 @@ public sealed class ModelProviderResolver : IModelProviderResolver
         {
             ProviderType.OpenAI => CreateOpenAIClient(provider),
             ProviderType.OpenRouter => CreateOpenRouterClient(provider),
+            ProviderType.LlamaCpp => CreateLlamaCppClient(provider),
             ProviderType.AzureOpenAI => CreateAzureOpenAIClient(provider),
             ProviderType.AzureAIInference => CreateAzureAIInferenceClient(provider),
             ProviderType.Ollama => CreateOllamaClient(provider),
@@ -76,13 +77,14 @@ public sealed class ModelProviderResolver : IModelProviderResolver
         {
             ProviderType.OpenAI => CreateOpenAIEmbeddingGenerator(provider),
             ProviderType.OpenRouter => CreateOpenRouterEmbeddingGenerator(provider),
+            ProviderType.LlamaCpp => CreateLlamaCppEmbeddingGenerator(provider),
             ProviderType.AzureOpenAI => CreateAzureOpenAIEmbeddingGenerator(provider),
             ProviderType.AzureAIInference => CreateAzureAIInferenceEmbeddingGenerator(provider),
             ProviderType.Ollama => CreateOllamaEmbeddingGenerator(provider),
             ProviderType.GoogleGemini => CreateGeminiEmbeddingGenerator(provider),
             _ => throw new NotSupportedException(
                 $"Provider type '{provider.ProviderType}' does not support embedding generation. " +
-                "Supported types: OpenAI, OpenRouter, AzureOpenAI, AzureAIInference, Ollama, GoogleGemini.")
+                "Supported types: OpenAI, OpenRouter, LlamaCpp, AzureOpenAI, AzureAIInference, Ollama, GoogleGemini.")
         };
     }
 
@@ -149,6 +151,14 @@ public sealed class ModelProviderResolver : IModelProviderResolver
             .Build();
     }
 
+    private static IChatClient CreateLlamaCppClient(ModelProvider provider)
+    {
+        var client = new OpenAIClient(
+            new ApiKeyCredential(provider.Auth.ApiKey ?? "unused"),
+            CreateLlamaCppOptions(provider.Endpoint));
+        return client.GetChatClient(provider.ModelName).AsIChatClient();
+    }
+
     private static OpenAIClientOptions CreateOpenAiCompatibleOptions(string? endpoint, string? defaultEndpoint = null)
     {
         var options = new OpenAIClientOptions();
@@ -159,6 +169,19 @@ public sealed class ModelProviderResolver : IModelProviderResolver
         }
 
         return options;
+    }
+
+    private static OpenAIClientOptions CreateLlamaCppOptions(string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+            throw new InvalidOperationException("llama.cpp provider requires an endpoint URL");
+
+        var builder = new UriBuilder(endpoint);
+        var path = builder.Path.TrimEnd('/');
+        if (!path.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            builder.Path = $"{path}/v1";
+
+        return new OpenAIClientOptions { Endpoint = builder.Uri };
     }
 
     private static IChatClient CreateAzureOpenAIClient(ModelProvider provider)
@@ -336,6 +359,18 @@ public sealed class ModelProviderResolver : IModelProviderResolver
         return client.GetEmbeddingClient(provider.ModelName).AsIEmbeddingGenerator()
             .AsBuilder()
             .UseOpenTelemetry(sourceName: "lucia", configure: (cfg) =>
+                cfg.EnableSensitiveData = true)
+            .Build();
+    }
+
+    private static IEmbeddingGenerator<string, Embedding<float>> CreateLlamaCppEmbeddingGenerator(ModelProvider provider)
+    {
+        var client = new OpenAIClient(
+            new ApiKeyCredential(provider.Auth.ApiKey ?? "unused"),
+            CreateLlamaCppOptions(provider.Endpoint));
+        return client.GetEmbeddingClient(provider.ModelName).AsIEmbeddingGenerator()
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: "lucia", configure: cfg =>
                 cfg.EnableSensitiveData = true)
             .Build();
     }

--- a/lucia.Agents/Services/CascadingEntityResolver.cs
+++ b/lucia.Agents/Services/CascadingEntityResolver.cs
@@ -107,7 +107,8 @@ public sealed class CascadingEntityResolver : ICascadingEntityResolver
             candidateNames =
             [
                 candidateName,
-                .. candidateNames,
+                .. candidateNames.Where(name => intent.DeviceType is null
+                    || !string.Equals(name, intent.DeviceType, StringComparison.OrdinalIgnoreCase)),
             ];
         }
 

--- a/lucia.Agents/Services/CascadingEntityResolver.cs
+++ b/lucia.Agents/Services/CascadingEntityResolver.cs
@@ -99,12 +99,14 @@ public sealed class CascadingEntityResolver : ICascadingEntityResolver
 
         var candidateNames = intent.CandidateEntityNames;
         if (grounded is null
-            && intent.ExplicitLocation is not null
-            && intent.DeviceType is not null)
+            && intent.ExplicitLocation is not null)
         {
+            var candidateName = intent.DeviceType is null
+                ? intent.ExplicitLocation
+                : $"{intent.ExplicitLocation} {intent.DeviceType}";
             candidateNames =
             [
-                $"{intent.ExplicitLocation} {intent.DeviceType}",
+                candidateName,
                 .. candidateNames,
             ];
         }

--- a/lucia.Agents/Services/CascadingEntityResolver.cs
+++ b/lucia.Agents/Services/CascadingEntityResolver.cs
@@ -88,13 +88,6 @@ public sealed class CascadingEntityResolver : ICascadingEntityResolver
         }
 
         var grounded = GroundLocation(intent, callerArea, speakerId, snapshot);
-        if (intent.ExplicitLocation is not null && grounded is null)
-        {
-            return Bail(
-                BailReason.NoMatch,
-                $"Explicit location '{intent.ExplicitLocation}' not found in cache");
-        }
-
         var candidates = FilterByDomain(intent, grounded, domains, snapshot, callerAgentId);
         if (candidates.Count == 0)
         {
@@ -105,6 +98,17 @@ public sealed class CascadingEntityResolver : ICascadingEntityResolver
         }
 
         var candidateNames = intent.CandidateEntityNames;
+        if (grounded is null
+            && intent.ExplicitLocation is not null
+            && intent.DeviceType is not null)
+        {
+            candidateNames =
+            [
+                $"{intent.ExplicitLocation} {intent.DeviceType}",
+                .. candidateNames,
+            ];
+        }
+
         if (IsAreaOnlyCommand(intent, candidateNames, grounded))
         {
             return ResolveFromCandidates(candidates, grounded);

--- a/lucia.Agents/Services/EntityLocationService.cs
+++ b/lucia.Agents/Services/EntityLocationService.cs
@@ -350,10 +350,18 @@ public sealed class EntityLocationService : IEntityLocationService
             query, _snapshot.Floors, embeddingService, options ?? DefaultLocationOptions, ct).ConfigureAwait(false);
     }
 
-    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+    public Task<HierarchicalSearchResult> SearchHierarchyAsync(
         string query,
         HybridMatchOptions? options = null,
         IReadOnlyList<string>? domainFilter = null,
+        CancellationToken ct = default) =>
+        SearchHierarchyAsync(query, options, domainFilter, callerAgentId: null, ct);
+
+    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string? callerAgentId,
         CancellationToken ct = default)
     {
         await EnsureFreshAsync(ct).ConfigureAwait(false);
@@ -374,6 +382,13 @@ public sealed class EntityLocationService : IEntityLocationService
                 )
                 .ToList()
             : (IReadOnlyList<HomeAssistantEntity>)snap.Entities;
+        if (callerAgentId is not null)
+        {
+            filteredEntities = filteredEntities
+                .Where(entity => entity.IncludeForAgent is null
+                    || entity.IncludeForAgent.Contains(callerAgentId))
+                .ToList();
+        }
 
         if (embeddingService is not null)
         {

--- a/lucia.Agents/Services/EntityLocationService.cs
+++ b/lucia.Agents/Services/EntityLocationService.cs
@@ -21,7 +21,7 @@ namespace lucia.Agents.Services;
 /// All in-memory data is stored in immutable collections swapped atomically via <see cref="Volatile"/>.
 /// Redis provides 24h persistence; HA config registry is the source of truth.
 /// </summary>
-public sealed class EntityLocationService : IEntityLocationService
+public sealed class EntityLocationService : IEntityLocationService, IAgentFilteredEntityLocationService
 {
     private const string FloorsKey = "lucia:location:floors";
     private const string AreasKey = "lucia:location:areas";
@@ -355,14 +355,22 @@ public sealed class EntityLocationService : IEntityLocationService
         HybridMatchOptions? options = null,
         IReadOnlyList<string>? domainFilter = null,
         CancellationToken ct = default) =>
-        SearchHierarchyAsync(query, options, domainFilter, callerAgentId: null, ct);
+        SearchHierarchyCoreAsync(query, options, domainFilter, callerAgentId: null, ct);
 
-    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+    public Task<HierarchicalSearchResult> SearchHierarchyForAgentAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string callerAgentId,
+        CancellationToken ct = default) =>
+        SearchHierarchyCoreAsync(query, options, domainFilter, callerAgentId, ct);
+
+    private async Task<HierarchicalSearchResult> SearchHierarchyCoreAsync(
         string query,
         HybridMatchOptions? options,
         IReadOnlyList<string>? domainFilter,
         string? callerAgentId,
-        CancellationToken ct = default)
+        CancellationToken ct)
     {
         await EnsureFreshAsync(ct).ConfigureAwait(false);
 

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -30,7 +30,7 @@ internal sealed partial class QueryDecomposer
         "the", "a", "an", "in", "on", "of", "to", "for", "please", "my", "it"
     };
 
-    private static readonly HashSet<string> TargetUnitTokens = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> s_targetUnitTokens = new(StringComparer.OrdinalIgnoreCase)
     {
         "degree", "degrees", "percent", "percentage"
     };
@@ -293,7 +293,7 @@ internal sealed partial class QueryDecomposer
         var followsTo = index > 0
             && string.Equals(tokens[index - 1], "to", StringComparison.OrdinalIgnoreCase);
         var isTrailingValue = index == tokens.Count - 1
-            || (index == tokens.Count - 2 && TargetUnitTokens.Contains(tokens[index + 1]));
+            || (index == tokens.Count - 2 && s_targetUnitTokens.Contains(tokens[index + 1]));
         return followsTo || isTrailingValue;
     }
 
@@ -302,7 +302,7 @@ internal sealed partial class QueryDecomposer
         int index,
         string? action) =>
         index > 0
-        && TargetUnitTokens.Contains(tokens[index])
+        && s_targetUnitTokens.Contains(tokens[index])
         && IsTargetValueToken(tokens, index - 1, action);
 
     private static bool IsLeadingCommandVerb(IReadOnlyList<string> tokens, int index)

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -230,7 +230,16 @@ internal sealed partial class QueryDecomposer
         {
             var token = tokens[i];
             if (string.Equals(token, "to", StringComparison.OrdinalIgnoreCase))
-                break;
+            {
+                if (i < end
+                    && double.TryParse(tokens[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                {
+                    break;
+                }
+
+                phraseTokens.Add(token);
+                continue;
+            }
 
             if (IgnoreTokens.Contains(token))
                 continue;

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -207,7 +207,7 @@ internal sealed partial class QueryDecomposer
         var remaining = tokens
             .Select(static (token, index) => (Token: token, Index: index))
             .Where(item => !ActionTokens.Contains(item.Token))
-            .Where(item => !ActionValues.Contains(item.Token))
+            .Where(item => !string.Equals(item.Token, action, StringComparison.OrdinalIgnoreCase))
             .Where(item => !IgnoreTokens.Contains(item.Token))
             .Where(item => explicitTokens.Length == 0
                 || !explicitTokens.Contains(item.Token, StringComparer.OrdinalIgnoreCase))
@@ -267,7 +267,8 @@ internal sealed partial class QueryDecomposer
             if (deviceType is not null && string.Equals(token, deviceType, StringComparison.OrdinalIgnoreCase))
                 break;
 
-            if (ActionTokens.Contains(token) || ActionValues.Contains(token))
+            if (ActionTokens.Contains(token)
+                || string.Equals(token, action, StringComparison.OrdinalIgnoreCase))
                 continue;
 
             phraseTokens.Add(token);

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -194,12 +194,16 @@ internal sealed partial class QueryDecomposer
             : explicitLocation.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         var remaining = tokens
-            .Where(t => !ActionTokens.Contains(t))
-            .Where(t => !ActionValues.Contains(t))
-            .Where(t => !IgnoreTokens.Contains(t))
-            .Where(t => explicitTokens.Length == 0 || !explicitTokens.Contains(t, StringComparer.OrdinalIgnoreCase))
-            .Where(t => deviceType is null || !string.Equals(t, deviceType, StringComparison.OrdinalIgnoreCase))
-            .Where(t => !double.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+            .Select(static (token, index) => (Token: token, Index: index))
+            .Where(item => !ActionTokens.Contains(item.Token))
+            .Where(item => !ActionValues.Contains(item.Token))
+            .Where(item => !IgnoreTokens.Contains(item.Token))
+            .Where(item => explicitTokens.Length == 0
+                || !explicitTokens.Contains(item.Token, StringComparer.OrdinalIgnoreCase))
+            .Where(item => deviceType is null
+                || !string.Equals(item.Token, deviceType, StringComparison.OrdinalIgnoreCase))
+            .Where(item => !IsTargetValueToken(tokens, item.Index))
+            .Select(static item => item.Token)
             .ToArray();
 
         if (remaining.Length > 0)
@@ -231,8 +235,7 @@ internal sealed partial class QueryDecomposer
             var token = tokens[i];
             if (string.Equals(token, "to", StringComparison.OrdinalIgnoreCase))
             {
-                if (i < end
-                    && double.TryParse(tokens[i + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+                if (i < end && IsTargetValueToken(tokens, i + 1))
                 {
                     break;
                 }
@@ -257,6 +260,11 @@ internal sealed partial class QueryDecomposer
             ? null
             : string.Join(' ', phraseTokens);
     }
+
+    private static bool IsTargetValueToken(IReadOnlyList<string> tokens, int index) =>
+        index > 0
+        && string.Equals(tokens[index - 1], "to", StringComparison.OrdinalIgnoreCase)
+        && double.TryParse(tokens[index], NumberStyles.Float, CultureInfo.InvariantCulture, out _);
 
     private static int IndexOf(IReadOnlyList<string> tokens, string value)
     {

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -30,6 +30,11 @@ internal sealed partial class QueryDecomposer
         "the", "a", "an", "in", "on", "of", "to", "for", "please", "my", "it"
     };
 
+    private static readonly HashSet<string> TargetUnitTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "degree", "degrees", "percent", "percentage"
+    };
+
     private static readonly HashSet<string> ConjunctionTokens = new(StringComparer.OrdinalIgnoreCase)
     {
         "and", "then", "also"
@@ -209,6 +214,7 @@ internal sealed partial class QueryDecomposer
             .Where(item => deviceType is null
                 || !string.Equals(item.Token, deviceType, StringComparison.OrdinalIgnoreCase))
             .Where(item => !IsTargetValueToken(tokens, item.Index, action))
+            .Where(item => !IsTargetUnitToken(tokens, item.Index, action))
             .Select(static item => item.Token)
             .ToArray();
 
@@ -280,6 +286,14 @@ internal sealed partial class QueryDecomposer
         && index > 0
         && string.Equals(tokens[index - 1], "to", StringComparison.OrdinalIgnoreCase)
         && double.TryParse(tokens[index], NumberStyles.Float, CultureInfo.InvariantCulture, out _);
+
+    private static bool IsTargetUnitToken(
+        IReadOnlyList<string> tokens,
+        int index,
+        string? action) =>
+        index > 0
+        && TargetUnitTokens.Contains(tokens[index])
+        && IsTargetValueToken(tokens, index - 1, action);
 
     private static int IndexOf(IReadOnlyList<string> tokens, string value)
     {

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -206,7 +206,7 @@ internal sealed partial class QueryDecomposer
 
         var remaining = tokens
             .Select(static (token, index) => (Token: token, Index: index))
-            .Where(item => !ActionTokens.Contains(item.Token))
+            .Where(item => !IsLeadingCommandVerb(tokens, item.Index))
             .Where(item => !string.Equals(item.Token, action, StringComparison.OrdinalIgnoreCase))
             .Where(item => !IgnoreTokens.Contains(item.Token))
             .Where(item => explicitTokens.Length == 0
@@ -267,7 +267,7 @@ internal sealed partial class QueryDecomposer
             if (deviceType is not null && string.Equals(token, deviceType, StringComparison.OrdinalIgnoreCase))
                 break;
 
-            if (ActionTokens.Contains(token)
+            if (IsLeadingCommandVerb(tokens, i)
                 || string.Equals(token, action, StringComparison.OrdinalIgnoreCase))
                 continue;
 
@@ -304,6 +304,20 @@ internal sealed partial class QueryDecomposer
         index > 0
         && TargetUnitTokens.Contains(tokens[index])
         && IsTargetValueToken(tokens, index - 1, action);
+
+    private static bool IsLeadingCommandVerb(IReadOnlyList<string> tokens, int index)
+    {
+        if (!ActionTokens.Contains(tokens[index]))
+            return false;
+
+        for (var precedingIndex = 0; precedingIndex < index; precedingIndex++)
+        {
+            if (!IgnoreTokens.Contains(tokens[precedingIndex]))
+                return false;
+        }
+
+        return true;
+    }
 
     private static int IndexOf(IReadOnlyList<string> tokens, string value)
     {

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
+using lucia.Agents.Integration;
 using lucia.Agents.Models;
 
 namespace lucia.Agents.Services;
@@ -53,12 +54,13 @@ internal sealed partial class QueryDecomposer
 
         var action = ExtractAction(tokens);
         var deviceType = ExtractDeviceType(tokens);
-        var explicitLocation = ExtractExplicitLocation(tokens, deviceType);
+        var explicitLocation = ExtractExplicitLocation(tokens, action, deviceType);
 
         var (isComplex, complexityReason) = DetectComplexity(tokens, normalized);
 
         var candidateAreas = BuildCandidateAreas(explicitLocation, hasMy, speakerId);
-        var candidateEntities = BuildCandidateEntities(tokens, explicitLocation, deviceType, hasMy, speakerId);
+        var candidateEntities = BuildCandidateEntities(
+            tokens, action, explicitLocation, deviceType, hasMy, speakerId);
 
         return new QueryIntent
         {
@@ -104,7 +106,10 @@ internal sealed partial class QueryDecomposer
         return null;
     }
 
-    private static string? ExtractExplicitLocation(IReadOnlyList<string> tokens, string? deviceType)
+    private static string? ExtractExplicitLocation(
+        IReadOnlyList<string> tokens,
+        string? action,
+        string? deviceType)
     {
         if (tokens.Count == 0)
             return null;
@@ -120,12 +125,12 @@ internal sealed partial class QueryDecomposer
             if (start < tokens.Count && (tokens[start] is "the" or "my"))
                 start++;
 
-            return BuildPhrase(tokens, start, tokens.Count - 1, deviceType);
+            return BuildPhrase(tokens, start, tokens.Count - 1, action, deviceType);
         }
 
         if (deviceTypeIndex > 0)
         {
-            var phrase = BuildPhrase(tokens, 0, deviceTypeIndex - 1, deviceType);
+            var phrase = BuildPhrase(tokens, 0, deviceTypeIndex - 1, action, deviceType);
             if (!string.IsNullOrWhiteSpace(phrase))
                 return phrase;
         }
@@ -133,7 +138,7 @@ internal sealed partial class QueryDecomposer
         var myIndex = IndexOf(tokens, "my");
         if (myIndex >= 0 && myIndex < tokens.Count - 1)
         {
-            var phrase = BuildPhrase(tokens, myIndex + 1, tokens.Count - 1, deviceType);
+            var phrase = BuildPhrase(tokens, myIndex + 1, tokens.Count - 1, action, deviceType);
             if (!string.IsNullOrWhiteSpace(phrase))
                 return phrase;
         }
@@ -141,7 +146,7 @@ internal sealed partial class QueryDecomposer
         var theIndex = IndexOf(tokens, "the");
         if (theIndex >= 0 && theIndex < tokens.Count - 1)
         {
-            var phrase = BuildPhrase(tokens, theIndex + 1, tokens.Count - 1, deviceType);
+            var phrase = BuildPhrase(tokens, theIndex + 1, tokens.Count - 1, action, deviceType);
             if (!string.IsNullOrWhiteSpace(phrase))
                 return phrase;
         }
@@ -183,6 +188,7 @@ internal sealed partial class QueryDecomposer
 
     private static IReadOnlyList<string> BuildCandidateEntities(
         IReadOnlyList<string> tokens,
+        string? action,
         string? explicitLocation,
         string? deviceType,
         bool hasMy,
@@ -202,7 +208,7 @@ internal sealed partial class QueryDecomposer
                 || !explicitTokens.Contains(item.Token, StringComparer.OrdinalIgnoreCase))
             .Where(item => deviceType is null
                 || !string.Equals(item.Token, deviceType, StringComparison.OrdinalIgnoreCase))
-            .Where(item => !IsTargetValueToken(tokens, item.Index))
+            .Where(item => !IsTargetValueToken(tokens, item.Index, action))
             .Select(static item => item.Token)
             .ToArray();
 
@@ -224,7 +230,12 @@ internal sealed partial class QueryDecomposer
         return candidates;
     }
 
-    private static string? BuildPhrase(IReadOnlyList<string> tokens, int start, int end, string? deviceType)
+    private static string? BuildPhrase(
+        IReadOnlyList<string> tokens,
+        int start,
+        int end,
+        string? action,
+        string? deviceType)
     {
         if (start < 0 || end < start || start >= tokens.Count)
             return null;
@@ -235,7 +246,7 @@ internal sealed partial class QueryDecomposer
             var token = tokens[i];
             if (string.Equals(token, "to", StringComparison.OrdinalIgnoreCase))
             {
-                if (i < end && IsTargetValueToken(tokens, i + 1))
+                if (i < end && IsTargetValueToken(tokens, i + 1, action))
                 {
                     break;
                 }
@@ -261,8 +272,12 @@ internal sealed partial class QueryDecomposer
             : string.Join(' ', phraseTokens);
     }
 
-    private static bool IsTargetValueToken(IReadOnlyList<string> tokens, int index) =>
-        index > 0
+    private static bool IsTargetValueToken(
+        IReadOnlyList<string> tokens,
+        int index,
+        string? action) =>
+        action is "set" or "dim" or "brighten" or "increase" or "decrease"
+        && index > 0
         && string.Equals(tokens[index - 1], "to", StringComparison.OrdinalIgnoreCase)
         && double.TryParse(tokens[index], NumberStyles.Float, CultureInfo.InvariantCulture, out _);
 
@@ -283,7 +298,7 @@ internal sealed partial class QueryDecomposer
             return string.Empty;
 
         var result = transcript.ToLowerInvariant().Trim();
-        result = Punctuation().Replace(result, " ");
+        result = CommandTextNormalizer.NormalizePunctuation(result);
         result = MultipleSpaces().Replace(result, " ").Trim();
         return result;
     }
@@ -298,9 +313,6 @@ internal sealed partial class QueryDecomposer
 
     [GeneratedRegex(@"\s+")]
     private static partial Regex MultipleSpaces();
-
-    [GeneratedRegex(@"[^\w\s]")]
-    private static partial Regex Punctuation();
 
     [GeneratedRegex(@"\b(in|after|before)\s+\d+|\b\d+\s*(seconds?|minutes?|hours?)\b|\bat\s+\d+|\btomorrow\b|\btonight\b",
         RegexOptions.IgnoreCase,

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -281,11 +281,20 @@ internal sealed partial class QueryDecomposer
     private static bool IsTargetValueToken(
         IReadOnlyList<string> tokens,
         int index,
-        string? action) =>
-        action is "set" or "dim" or "brighten" or "increase" or "decrease"
-        && index > 0
-        && string.Equals(tokens[index - 1], "to", StringComparison.OrdinalIgnoreCase)
-        && double.TryParse(tokens[index], NumberStyles.Float, CultureInfo.InvariantCulture, out _);
+        string? action)
+    {
+        if (action is not ("set" or "dim" or "brighten" or "increase" or "decrease")
+            || !double.TryParse(tokens[index], NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+        {
+            return false;
+        }
+
+        var followsTo = index > 0
+            && string.Equals(tokens[index - 1], "to", StringComparison.OrdinalIgnoreCase);
+        var isTrailingValue = index == tokens.Count - 1
+            || (index == tokens.Count - 2 && TargetUnitTokens.Contains(tokens[index + 1]));
+        return followsTo || isTrailingValue;
+    }
 
     private static bool IsTargetUnitToken(
         IReadOnlyList<string> tokens,

--- a/lucia.Agents/Services/QueryDecomposer.cs
+++ b/lucia.Agents/Services/QueryDecomposer.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 using lucia.Agents.Models;
 
@@ -7,12 +8,13 @@ internal sealed partial class QueryDecomposer
 {
     private static readonly HashSet<string> ActionTokens = new(StringComparer.OrdinalIgnoreCase)
     {
-        "turn", "switch", "set", "toggle", "dim", "brighten", "increase", "decrease"
+        "turn", "switch", "set", "toggle", "dim", "brighten", "increase", "decrease", "make", "activate"
     };
 
     private static readonly HashSet<string> ActionValues = new(StringComparer.OrdinalIgnoreCase)
     {
-        "on", "off", "toggle", "dim", "brighten", "set", "increase", "decrease"
+        "on", "off", "toggle", "dim", "brighten", "set", "increase", "decrease",
+        "warmer", "cooler", "hotter", "colder", "activate"
     };
 
     private static readonly HashSet<string> DeviceTypeTokens = new(StringComparer.OrdinalIgnoreCase)
@@ -24,7 +26,7 @@ internal sealed partial class QueryDecomposer
 
     private static readonly HashSet<string> IgnoreTokens = new(StringComparer.OrdinalIgnoreCase)
     {
-        "the", "a", "an", "in", "on", "of", "to", "for", "please", "my"
+        "the", "a", "an", "in", "on", "of", "to", "for", "please", "my", "it"
     };
 
     private static readonly HashSet<string> ConjunctionTokens = new(StringComparer.OrdinalIgnoreCase)
@@ -197,6 +199,7 @@ internal sealed partial class QueryDecomposer
             .Where(t => !IgnoreTokens.Contains(t))
             .Where(t => explicitTokens.Length == 0 || !explicitTokens.Contains(t, StringComparer.OrdinalIgnoreCase))
             .Where(t => deviceType is null || !string.Equals(t, deviceType, StringComparison.OrdinalIgnoreCase))
+            .Where(t => !double.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
             .ToArray();
 
         if (remaining.Length > 0)
@@ -226,6 +229,9 @@ internal sealed partial class QueryDecomposer
         for (var i = start; i <= end && i < tokens.Count; i++)
         {
             var token = tokens[i];
+            if (string.Equals(token, "to", StringComparison.OrdinalIgnoreCase))
+                break;
+
             if (IgnoreTokens.Contains(token))
                 continue;
 
@@ -260,7 +266,7 @@ internal sealed partial class QueryDecomposer
             return string.Empty;
 
         var result = transcript.ToLowerInvariant().Trim();
-        result = Punctuation().Replace(result, "");
+        result = Punctuation().Replace(result, " ");
         result = MultipleSpaces().Replace(result, " ").Trim();
         return result;
     }

--- a/lucia.Agents/Skills/ClimateControlSkill.cs
+++ b/lucia.Agents/Skills/ClimateControlSkill.cs
@@ -96,8 +96,8 @@ public sealed class ClimateControlSkill : IAgentSkill, IOptimizableSkill, IComma
             Action = "set_temperature",
             Templates =
             [
-                "set [the] {entity} [temperature] to {value} [degrees]",
-                "set [the] thermostat [in] [the] {area} to {value}",
+                "{action:set} [the] {entity} [temperature] to {value} [degrees]",
+                "{action:set} [the] thermostat [in] [the] {area} to {value}",
             ],
         },
         new()

--- a/lucia.Data/InMemory/InMemoryEntityLocationService.cs
+++ b/lucia.Data/InMemory/InMemoryEntityLocationService.cs
@@ -19,7 +19,7 @@ namespace lucia.Data.InMemory;
 /// and stores all location data in-process without any Redis persistence.
 /// Designed for lightweight/mono-container deployments where cross-process cache sharing is not needed.
 /// </summary>
-public sealed class InMemoryEntityLocationService : IEntityLocationService
+public sealed class InMemoryEntityLocationService : IEntityLocationService, IAgentFilteredEntityLocationService
 {
     private const int EmbeddingBatchSize = 25;
     private const int EmbeddingBatchMaxAttempts = 3;
@@ -235,14 +235,22 @@ public sealed class InMemoryEntityLocationService : IEntityLocationService
         HybridMatchOptions? options = null,
         IReadOnlyList<string>? domainFilter = null,
         CancellationToken ct = default) =>
-        SearchHierarchyAsync(query, options, domainFilter, callerAgentId: null, ct);
+        SearchHierarchyCoreAsync(query, options, domainFilter, callerAgentId: null, ct);
 
-    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+    public Task<HierarchicalSearchResult> SearchHierarchyForAgentAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string callerAgentId,
+        CancellationToken ct = default) =>
+        SearchHierarchyCoreAsync(query, options, domainFilter, callerAgentId, ct);
+
+    private async Task<HierarchicalSearchResult> SearchHierarchyCoreAsync(
         string query,
         HybridMatchOptions? options,
         IReadOnlyList<string>? domainFilter,
         string? callerAgentId,
-        CancellationToken ct = default)
+        CancellationToken ct)
     {
         await EnsureLoadedAsync(ct).ConfigureAwait(false);
 

--- a/lucia.Data/InMemory/InMemoryEntityLocationService.cs
+++ b/lucia.Data/InMemory/InMemoryEntityLocationService.cs
@@ -230,10 +230,18 @@ public sealed class InMemoryEntityLocationService : IEntityLocationService
             query, _snapshot.Floors, embeddingService, options ?? DefaultLocationOptions, ct).ConfigureAwait(false);
     }
 
-    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+    public Task<HierarchicalSearchResult> SearchHierarchyAsync(
         string query,
         HybridMatchOptions? options = null,
         IReadOnlyList<string>? domainFilter = null,
+        CancellationToken ct = default) =>
+        SearchHierarchyAsync(query, options, domainFilter, callerAgentId: null, ct);
+
+    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string? callerAgentId,
         CancellationToken ct = default)
     {
         await EnsureLoadedAsync(ct).ConfigureAwait(false);
@@ -252,6 +260,13 @@ public sealed class InMemoryEntityLocationService : IEntityLocationService
                     (e.IncludeForAgent == null || e.IncludeForAgent.Count > 0))
                 .ToList()
             : (IReadOnlyList<HomeAssistantEntity>)snap.Entities;
+        if (callerAgentId is not null)
+        {
+            filteredEntities = filteredEntities
+                .Where(entity => entity.IncludeForAgent is null
+                    || entity.IncludeForAgent.Contains(callerAgentId))
+                .ToList();
+        }
 
         if (embeddingService is not null)
         {

--- a/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
+++ b/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
@@ -138,7 +138,9 @@ public sealed class DirectSkillExecutorTests
     public async Task ExecuteAsync_CascadeMiss_UsesEmbeddingEntityMatch()
     {
         var haClient = A.Fake<IHomeAssistantClient>();
-        var locationService = A.Fake<IEntityLocationService>();
+        var locationService = A.Fake<IEntityLocationService>(
+            options => options.Implements<IAgentFilteredEntityLocationService>());
+        var filteredLocationService = (IAgentFilteredEntityLocationService)locationService;
         var cascadingResolver = A.Fake<ICascadingEntityResolver>();
         var featureManager = A.Fake<IFeatureManager>();
         var options = A.Fake<IOptionsMonitor<LightControlSkillOptions>>();
@@ -166,7 +168,7 @@ public sealed class DirectSkillExecutorTests
                 BailReason = BailReason.NoMatch,
                 Explanation = "No deterministic match"
             });
-        A.CallTo(() => locationService.SearchHierarchyAsync(
+        A.CallTo(() => filteredLocationService.SearchHierarchyForAgentAsync(
                 "Zach's light",
                 A<HybridMatchOptions?>._,
                 A<IReadOnlyList<string>?>._,
@@ -228,7 +230,7 @@ public sealed class DirectSkillExecutorTests
         var result = await executor.ExecuteAsync(route, CreateContext());
 
         Assert.True(result.Success, result.Error);
-        A.CallTo(() => locationService.SearchHierarchyAsync(
+        A.CallTo(() => filteredLocationService.SearchHierarchyForAgentAsync(
                 "Zach's light",
                 A<HybridMatchOptions?>.That.Matches(matchOptions => HasExpectedThreshold(matchOptions)),
                 A<IReadOnlyList<string>?>._,

--- a/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
+++ b/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
@@ -147,7 +147,10 @@ public sealed class DirectSkillExecutorTests
         };
 
         A.CallTo(() => featureManager.IsEnabledAsync(A<string>._)).Returns(true);
-        A.CallTo(() => options.CurrentValue).Returns(new LightControlSkillOptions());
+        A.CallTo(() => options.CurrentValue).Returns(new LightControlSkillOptions
+        {
+            HybridSimilarityThreshold = 0.77
+        });
         A.CallTo(() => cascadingResolver.Resolve(
                 A<string>._,
                 A<string?>._,
@@ -222,6 +225,12 @@ public sealed class DirectSkillExecutorTests
         var result = await executor.ExecuteAsync(route, CreateContext());
 
         Assert.True(result.Success, result.Error);
+        A.CallTo(() => locationService.SearchHierarchyAsync(
+                "Zach's light",
+                A<HybridMatchOptions?>.That.Matches(matchOptions => HasExpectedThreshold(matchOptions)),
+                A<IReadOnlyList<string>?>._,
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
         A.CallTo(() => haClient.CallServiceAsync(
                 "light",
                 "turn_off",
@@ -291,6 +300,9 @@ public sealed class DirectSkillExecutorTests
         Assert.Equal("LightControlSkill", result.SkillId);
         Assert.NotNull(result.Error);
     }
+
+    private static bool HasExpectedThreshold(HybridMatchOptions? matchOptions) =>
+        matchOptions is { Threshold: 0.77 };
 
     private static ConversationContext CreateContext() => new()
     {

--- a/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
+++ b/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
@@ -133,6 +133,105 @@ public sealed class DirectSkillExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_CascadeMiss_UsesEmbeddingEntityMatch()
+    {
+        var haClient = A.Fake<IHomeAssistantClient>();
+        var locationService = A.Fake<IEntityLocationService>();
+        var cascadingResolver = A.Fake<ICascadingEntityResolver>();
+        var featureManager = A.Fake<IFeatureManager>();
+        var options = A.Fake<IOptionsMonitor<LightControlSkillOptions>>();
+        var entity = new HomeAssistantEntity
+        {
+            EntityId = "light.zacks_light",
+            FriendlyName = "Zack's Light"
+        };
+
+        A.CallTo(() => featureManager.IsEnabledAsync(A<string>._)).Returns(true);
+        A.CallTo(() => options.CurrentValue).Returns(new LightControlSkillOptions());
+        A.CallTo(() => cascadingResolver.Resolve(
+                A<string>._,
+                A<string?>._,
+                A<string?>._,
+                A<IReadOnlyList<string>>._,
+                A<string?>._,
+                A<CancellationToken>._))
+            .Returns(new CascadeResult
+            {
+                IsResolved = false,
+                BailReason = BailReason.NoMatch,
+                Explanation = "No deterministic match"
+            });
+        A.CallTo(() => locationService.SearchHierarchyAsync(
+                "Zach's light",
+                A<HybridMatchOptions?>._,
+                A<IReadOnlyList<string>?>._,
+                A<CancellationToken>._))
+            .Returns(new HierarchicalSearchResult
+            {
+                FloorMatches = [],
+                AreaMatches = [],
+                EntityMatches = [],
+                ResolvedEntities = [entity],
+                ResolutionStrategy = ResolutionStrategy.Entity,
+                ResolutionReason = "Embedding match"
+            });
+        A.CallTo(() => locationService.ExactMatchEntities(
+                "light.zacks_light",
+                A<IReadOnlyList<string>?>._))
+            .Returns([entity]);
+        A.CallTo(() => haClient.CallServiceAsync(
+                A<string>._,
+                A<string>._,
+                A<string?>._,
+                A<ServiceCallRequest?>._,
+                A<CancellationToken>._))
+            .Returns([]);
+
+        var skill = new LightControlSkill(
+            haClient,
+            A.Fake<ILogger<LightControlSkill>>(),
+            locationService,
+            options);
+        A.CallTo(() => _serviceProvider.GetService(typeof(LightControlSkill))).Returns(skill);
+
+        var executor = new DirectSkillExecutor(
+            _serviceProvider,
+            locationService,
+            cascadingResolver,
+            featureManager,
+            A.Fake<ILogger<DirectSkillExecutor>>());
+        var route = new CommandRouteResult
+        {
+            IsMatch = true,
+            Confidence = 0.95f,
+            NormalizedTranscript = "turn off zach's light",
+            MatchedPattern = new CommandPattern
+            {
+                Id = "light-toggle",
+                SkillId = "LightControlSkill",
+                Action = "toggle",
+                Templates = ["turn {action} {entity}"]
+            },
+            CapturedValues = new Dictionary<string, string>
+            {
+                ["action"] = "off",
+                ["entity"] = "Zach's light"
+            }
+        };
+
+        var result = await executor.ExecuteAsync(route, CreateContext());
+
+        Assert.True(result.Success, result.Error);
+        A.CallTo(() => haClient.CallServiceAsync(
+                "light",
+                "turn_off",
+                A<string?>._,
+                A<ServiceCallRequest?>._,
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_UnsupportedSkillAction_ReturnsFailed()
     {
         // Arrange — route matches an unknown skill/action combo

--- a/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
+++ b/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
@@ -3,6 +3,7 @@ using lucia.AgentHost.Conversation.Execution;
 using lucia.AgentHost.Conversation.Models;
 using lucia.Agents.Abstractions;
 using lucia.Agents.Configuration;
+using lucia.Agents.Configuration.UserConfiguration;
 using lucia.Agents.Models;
 using lucia.Agents.Models.HomeAssistant;
 using lucia.Agents.Services;
@@ -10,6 +11,7 @@ using lucia.Agents.Skills;
 using lucia.HomeAssistant.Models;
 using lucia.HomeAssistant.Services;
 using lucia.Wyoming.CommandRouting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -168,6 +170,7 @@ public sealed class DirectSkillExecutorTests
                 "Zach's light",
                 A<HybridMatchOptions?>._,
                 A<IReadOnlyList<string>?>._,
+                "light-agent",
                 A<CancellationToken>._))
             .Returns(new HierarchicalSearchResult
             {
@@ -229,6 +232,7 @@ public sealed class DirectSkillExecutorTests
                 "Zach's light",
                 A<HybridMatchOptions?>.That.Matches(matchOptions => HasExpectedThreshold(matchOptions)),
                 A<IReadOnlyList<string>?>._,
+                "light-agent",
                 A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => haClient.CallServiceAsync(
@@ -238,6 +242,55 @@ public sealed class DirectSkillExecutorTests
                 A<ServiceCallRequest?>._,
                 A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Theory]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    public async Task ExecuteAsync_ClimateNonFiniteTemperature_ReturnsFailed(string value)
+    {
+        var haClient = A.Fake<IHomeAssistantClient>();
+        var options = A.Fake<IOptionsMonitor<ClimateControlSkillOptions>>();
+        A.CallTo(() => options.CurrentValue).Returns(new ClimateControlSkillOptions());
+        var skill = new ClimateControlSkill(
+            haClient,
+            A.Fake<IEmbeddingProviderResolver>(),
+            A.Fake<ILogger<ClimateControlSkill>>(),
+            A.Fake<IDeviceCacheService>(),
+            _entityLocationService,
+            A.Fake<IHybridEntityMatcher>(),
+            options,
+            new ConfigurationBuilder().Build());
+        A.CallTo(() => _serviceProvider.GetService(typeof(ClimateControlSkill))).Returns(skill);
+        var route = new CommandRouteResult
+        {
+            IsMatch = true,
+            Confidence = 0.9f,
+            MatchedPattern = new CommandPattern
+            {
+                Id = "climate-set",
+                SkillId = "ClimateControlSkill",
+                Action = "set_temperature",
+                Templates = ["set {entity} to {value}"]
+            },
+            CapturedValues = new Dictionary<string, string>
+            {
+                ["entity"] = "office",
+                ["value"] = value
+            }
+        };
+
+        var result = await _executor.ExecuteAsync(route, CreateContext());
+
+        Assert.False(result.Success);
+        Assert.Contains("finite", result.Error, StringComparison.OrdinalIgnoreCase);
+        A.CallTo(() => haClient.CallServiceAsync(
+                A<string>._,
+                A<string>._,
+                A<string?>._,
+                A<ServiceCallRequest?>._,
+                A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
+++ b/lucia.Tests/Conversation/DirectSkillExecutorTests.cs
@@ -293,6 +293,51 @@ public sealed class DirectSkillExecutorTests
             .MustNotHaveHappened();
     }
 
+    [Theory]
+    [InlineData("-5")]
+    [InlineData("101")]
+    public async Task ExecuteAsync_LightBrightnessOutsideRange_ReturnsFailed(string value)
+    {
+        var haClient = A.Fake<IHomeAssistantClient>();
+        var options = A.Fake<IOptionsMonitor<LightControlSkillOptions>>();
+        A.CallTo(() => options.CurrentValue).Returns(new LightControlSkillOptions());
+        var skill = new LightControlSkill(
+            haClient,
+            A.Fake<ILogger<LightControlSkill>>(),
+            _entityLocationService,
+            options);
+        A.CallTo(() => _serviceProvider.GetService(typeof(LightControlSkill))).Returns(skill);
+        var route = new CommandRouteResult
+        {
+            IsMatch = true,
+            Confidence = 0.9f,
+            MatchedPattern = new CommandPattern
+            {
+                Id = "light-brightness",
+                SkillId = "LightControlSkill",
+                Action = "brightness",
+                Templates = ["dim {entity} to {value}"]
+            },
+            CapturedValues = new Dictionary<string, string>
+            {
+                ["entity"] = "kitchen light",
+                ["value"] = value
+            }
+        };
+
+        var result = await _executor.ExecuteAsync(route, CreateContext());
+
+        Assert.False(result.Success);
+        Assert.Contains("0 and 100", result.Error, StringComparison.OrdinalIgnoreCase);
+        A.CallTo(() => haClient.CallServiceAsync(
+                A<string>._,
+                A<string>._,
+                A<string?>._,
+                A<ServiceCallRequest?>._,
+                A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
     [Fact]
     public async Task ExecuteAsync_UnsupportedSkillAction_ReturnsFailed()
     {

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -220,6 +220,88 @@ public sealed class CascadingEntityResolverTests
         Assert.Contains("light.zack_light", result.ResolvedEntityIds);
     }
 
+    [Fact]
+    public void Resolve_TurnOffNamedLight_MatchesEntityInsteadOfArea()
+    {
+        var entities = new[]
+        {
+            CreateEntity("light.zacks_light", "Zach's Light", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "turn off Zach's light",
+            callerArea: null,
+            speakerId: null,
+            domains: ["light", "switch"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("light.zacks_light", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
+    public void Resolve_SetOfficeTemperature_IgnoresTargetValueWhenGroundingArea()
+    {
+        var office = CreateArea("office", "Office");
+        var entities = new[]
+        {
+            CreateEntity("climate.office", "Office Thermostat", "office")
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [office], entities: entities));
+
+        var result = resolver.Resolve(
+            "set the office to 75",
+            callerArea: null,
+            speakerId: null,
+            domains: ["climate"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("climate.office", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
+    public void Resolve_MakeOfficeWarmer_RecognizesComfortAction()
+    {
+        var office = CreateArea("office", "Office");
+        var entities = new[]
+        {
+            CreateEntity("climate.office", "Office Thermostat", "office")
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [office], entities: entities));
+
+        var result = resolver.Resolve(
+            "make it warmer in the office",
+            callerArea: null,
+            speakerId: null,
+            domains: ["climate"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("climate.office", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
+    public void Resolve_ActivateNamedScene_RecognizesSceneAction()
+    {
+        var entities = new[]
+        {
+            CreateEntity("scene.movie", "Movie Scene", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "activate the movie scene",
+            callerArea: null,
+            speakerId: null,
+            domains: ["scene"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("scene.movie", Assert.Single(result.ResolvedEntityIds));
+    }
+
     // ── Floor-level resolution ─────────────────────────────────
 
     [Fact]

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -282,6 +282,26 @@ public sealed class CascadingEntityResolverTests
     }
 
     [Fact]
+    public void Resolve_EntityNamedLikeComfortAction_MatchesEntity()
+    {
+        var entities = new[]
+        {
+            CreateEntity("light.cooler", "Cooler Light", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "turn off cooler light",
+            callerArea: null,
+            speakerId: null,
+            domains: ["light", "switch"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("light.cooler", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
     public void Resolve_DimNamedLightWithoutTo_IgnoresBrightnessTarget()
     {
         var entities = new[]

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -282,6 +282,26 @@ public sealed class CascadingEntityResolverTests
     }
 
     [Fact]
+    public void Resolve_DimNamedLightWithoutTo_IgnoresBrightnessTarget()
+    {
+        var entities = new[]
+        {
+            CreateEntity("light.kitchen", "Kitchen Light", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "dim the kitchen light 50 percent",
+            callerArea: null,
+            speakerId: null,
+            domains: ["light", "switch"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("light.kitchen", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
     public void Resolve_SetOfficeTemperature_IgnoresTargetValueWhenGroundingArea()
     {
         var office = CreateArea("office", "Office");

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -241,6 +241,26 @@ public sealed class CascadingEntityResolverTests
     }
 
     [Fact]
+    public void Resolve_TurnOffNamedEntityWithoutDeviceType_MatchesEntity()
+    {
+        var entities = new[]
+        {
+            CreateEntity("light.chandelier", "Chandelier", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "turn off the chandelier",
+            callerArea: null,
+            speakerId: null,
+            domains: ["light", "switch"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("light.chandelier", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
     public void Resolve_SetOfficeTemperature_IgnoresTargetValueWhenGroundingArea()
     {
         var office = CreateArea("office", "Office");

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -272,7 +272,7 @@ public sealed class CascadingEntityResolverTests
             SetupLocationService(areas: [office], entities: entities));
 
         var result = resolver.Resolve(
-            "set the office to 75",
+            "set the office to 72.5",
             callerArea: null,
             speakerId: null,
             domains: ["climate"]);
@@ -307,19 +307,19 @@ public sealed class CascadingEntityResolverTests
     {
         var entities = new[]
         {
-            CreateEntity("scene.welcome_home", "Welcome to Home Scene", areaId: null)
+            CreateEntity("scene.welcome_2026", "Welcome to 2026 Scene", areaId: null)
         };
         var resolver = new CascadingEntityResolver(
             SetupLocationService(areas: [], entities: entities));
 
         var result = resolver.Resolve(
-            "activate welcome to home scene",
+            "activate welcome to 2026 scene",
             callerArea: null,
             speakerId: null,
             domains: ["scene"]);
 
         Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
-        Assert.Equal("scene.welcome_home", Assert.Single(result.ResolvedEntityIds));
+        Assert.Equal("scene.welcome_2026", Assert.Single(result.ResolvedEntityIds));
     }
 
     // ── Floor-level resolution ─────────────────────────────────

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -307,19 +307,19 @@ public sealed class CascadingEntityResolverTests
     {
         var entities = new[]
         {
-            CreateEntity("scene.movie", "Movie Scene", areaId: null)
+            CreateEntity("scene.welcome_home", "Welcome to Home Scene", areaId: null)
         };
         var resolver = new CascadingEntityResolver(
             SetupLocationService(areas: [], entities: entities));
 
         var result = resolver.Resolve(
-            "activate the movie scene",
+            "activate welcome to home scene",
             callerArea: null,
             speakerId: null,
             domains: ["scene"]);
 
         Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
-        Assert.Equal("scene.movie", Assert.Single(result.ResolvedEntityIds));
+        Assert.Equal("scene.welcome_home", Assert.Single(result.ResolvedEntityIds));
     }
 
     // ── Floor-level resolution ─────────────────────────────────

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -261,6 +261,27 @@ public sealed class CascadingEntityResolverTests
     }
 
     [Fact]
+    public void Resolve_NamedLight_DoesNotAlsoResolveGenericLight()
+    {
+        var entities = new[]
+        {
+            CreateEntity("light.kitchen", "Kitchen Light", areaId: null),
+            CreateEntity("light.generic", "Light", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "turn off kitchen light",
+            callerArea: null,
+            speakerId: null,
+            domains: ["light", "switch"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("light.kitchen", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
     public void Resolve_SetOfficeTemperature_IgnoresTargetValueWhenGroundingArea()
     {
         var office = CreateArea("office", "Office");
@@ -272,7 +293,7 @@ public sealed class CascadingEntityResolverTests
             SetupLocationService(areas: [office], entities: entities));
 
         var result = resolver.Resolve(
-            "set the office to 72.5",
+            "set the office to 72.5 degrees",
             callerArea: null,
             speakerId: null,
             domains: ["climate"]);

--- a/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
+++ b/lucia.Tests/EntityResolution/CascadingEntityResolverTests.cs
@@ -302,6 +302,26 @@ public sealed class CascadingEntityResolverTests
     }
 
     [Fact]
+    public void Resolve_EntityNamedLikeCommandVerb_MatchesEntity()
+    {
+        var entities = new[]
+        {
+            CreateEntity("light.activate", "Activate Light", areaId: null)
+        };
+        var resolver = new CascadingEntityResolver(
+            SetupLocationService(areas: [], entities: entities));
+
+        var result = resolver.Resolve(
+            "turn off activate light",
+            callerArea: null,
+            speakerId: null,
+            domains: ["light", "switch"]);
+
+        Assert.True(result.IsResolved, $"{result.BailReason}: {result.Explanation}");
+        Assert.Equal("light.activate", Assert.Single(result.ResolvedEntityIds));
+    }
+
+    [Fact]
     public void Resolve_DimNamedLightWithoutTo_IgnoresBrightnessTarget()
     {
         var entities = new[]

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -47,6 +47,14 @@ public sealed class QueryDecomposerTests
         Assert.Equal("welcome to home", intent.ExplicitLocation);
     }
 
+    [Fact]
+    public void Decompose_NumberedEntity_PreservesNumber()
+    {
+        var intent = QueryDecomposer.Decompose("turn on room 101", speakerId: null);
+
+        Assert.Contains("room 101", intent.CandidateEntityNames);
+    }
+
     // ── Complexity detection: temporal ──────────────────────────
 
     [Fact]

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -63,6 +63,14 @@ public sealed class QueryDecomposerTests
         Assert.Equal("cooler", intent.ExplicitLocation);
     }
 
+    [Fact]
+    public void Decompose_EntityNamedLikeCommandVerb_PreservesName()
+    {
+        var intent = QueryDecomposer.Decompose("turn off activate light", speakerId: null);
+
+        Assert.Equal("activate", intent.ExplicitLocation);
+    }
+
     [Theory]
     [InlineData("set the office to 73 degrees", "degrees")]
     [InlineData("dim the kitchen light to 50 percent", "percent")]

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -55,6 +55,14 @@ public sealed class QueryDecomposerTests
         Assert.Contains("room 101", intent.CandidateEntityNames);
     }
 
+    [Fact]
+    public void Decompose_EntityNamedLikeComfortAction_PreservesName()
+    {
+        var intent = QueryDecomposer.Decompose("turn off cooler light", speakerId: null);
+
+        Assert.Equal("cooler", intent.ExplicitLocation);
+    }
+
     [Theory]
     [InlineData("set the office to 73 degrees", "degrees")]
     [InlineData("dim the kitchen light to 50 percent", "percent")]

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -58,6 +58,7 @@ public sealed class QueryDecomposerTests
     [Theory]
     [InlineData("set the office to 73 degrees", "degrees")]
     [InlineData("dim the kitchen light to 50 percent", "percent")]
+    [InlineData("dim the kitchen light 50 percent", "percent")]
     public void Decompose_NumericTargetUnit_IsNotAnEntityCandidate(string command, string unit)
     {
         var intent = QueryDecomposer.Decompose(command, speakerId: null);

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -39,6 +39,14 @@ public sealed class QueryDecomposerTests
         Assert.Null(intent.ComplexityReason);
     }
 
+    [Fact]
+    public void Decompose_EntityNameContainingTo_PreservesFullName()
+    {
+        var intent = QueryDecomposer.Decompose("activate welcome to home scene", speakerId: null);
+
+        Assert.Equal("welcome to home", intent.ExplicitLocation);
+    }
+
     // ── Complexity detection: temporal ──────────────────────────
 
     [Fact]

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -55,6 +55,17 @@ public sealed class QueryDecomposerTests
         Assert.Contains("room 101", intent.CandidateEntityNames);
     }
 
+    [Theory]
+    [InlineData("set the office to 73 degrees", "degrees")]
+    [InlineData("dim the kitchen light to 50 percent", "percent")]
+    public void Decompose_NumericTargetUnit_IsNotAnEntityCandidate(string command, string unit)
+    {
+        var intent = QueryDecomposer.Decompose(command, speakerId: null);
+
+        Assert.DoesNotContain(intent.CandidateEntityNames, candidate =>
+            candidate.Contains(unit, StringComparison.OrdinalIgnoreCase));
+    }
+
     // ── Complexity detection: temporal ──────────────────────────
 
     [Fact]

--- a/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
+++ b/lucia.Tests/EntityResolution/QueryDecomposerTests.cs
@@ -42,9 +42,9 @@ public sealed class QueryDecomposerTests
     [Fact]
     public void Decompose_EntityNameContainingTo_PreservesFullName()
     {
-        var intent = QueryDecomposer.Decompose("activate welcome to home scene", speakerId: null);
+        var intent = QueryDecomposer.Decompose("activate welcome to 2026 scene", speakerId: null);
 
-        Assert.Equal("welcome to home", intent.ExplicitLocation);
+        Assert.Equal("welcome to 2026", intent.ExplicitLocation);
     }
 
     [Fact]

--- a/lucia.Tests/Services/ModelProviderResolverTests.cs
+++ b/lucia.Tests/Services/ModelProviderResolverTests.cs
@@ -121,7 +121,7 @@ public sealed class ModelProviderResolverTests
             ProviderType.LlamaCpp,
             endpoint: "http://localhost:8000/llama",
             model: "qwen3.5-9b",
-            apiKey: null);
+            apiKey: "");
         using var client = _resolver.CreateClient(provider);
         var metadata = Assert.IsType<ChatClientMetadata>(
             client.GetService(typeof(ChatClientMetadata)));
@@ -379,7 +379,7 @@ public sealed class ModelProviderResolverTests
             ProviderType.LlamaCpp,
             endpoint: "http://localhost:8000/",
             model: "embed-qwen3",
-            apiKey: null);
+            apiKey: "");
         var generator = _resolver.CreateEmbeddingGenerator(provider);
         var metadata = Assert.IsType<EmbeddingGeneratorMetadata>(
             generator.GetService(typeof(EmbeddingGeneratorMetadata)));

--- a/lucia.Tests/Services/ModelProviderResolverTests.cs
+++ b/lucia.Tests/Services/ModelProviderResolverTests.cs
@@ -112,6 +112,25 @@ public sealed class ModelProviderResolverTests
 
     #endregion
 
+    #region llama.cpp
+
+    [Fact]
+    public void CreateClient_LlamaCpp_WithoutApiKey_NormalizesEndpoint()
+    {
+        var provider = MakeProvider(
+            ProviderType.LlamaCpp,
+            endpoint: "http://localhost:8000/llama",
+            model: "qwen3.5-9b",
+            apiKey: null);
+        using var client = _resolver.CreateClient(provider);
+        var metadata = Assert.IsType<ChatClientMetadata>(
+            client.GetService(typeof(ChatClientMetadata)));
+
+        Assert.Equal(new Uri("http://localhost:8000/llama/v1"), metadata.ProviderUri);
+    }
+
+    #endregion
+
     #region Azure OpenAI
 
     [Fact]

--- a/lucia.Tests/Services/ModelProviderResolverTests.cs
+++ b/lucia.Tests/Services/ModelProviderResolverTests.cs
@@ -2,6 +2,7 @@ using lucia.Agents.Configuration;
 using lucia.Agents.Configuration.UserConfiguration;
 using lucia.Agents.Providers;
 using lucia.Tests.TestDoubles;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -346,7 +347,25 @@ public sealed class ModelProviderResolverTests
             endpoint: "https://custom-endpoint.example.com/v1",
             model: "text-embedding-3-small");
         var generator = _resolver.CreateEmbeddingGenerator(provider);
-        Assert.NotNull(generator);
+        var metadata = Assert.IsType<EmbeddingGeneratorMetadata>(
+            generator.GetService(typeof(EmbeddingGeneratorMetadata)));
+
+        Assert.Equal(new Uri("https://custom-endpoint.example.com/v1"), metadata.ProviderUri);
+    }
+
+    [Fact]
+    public void CreateEmbeddingGenerator_LlamaCpp_AppendsOpenAiVersionPath()
+    {
+        var provider = MakeProvider(
+            ProviderType.LlamaCpp,
+            endpoint: "http://localhost:8000/",
+            model: "embed-qwen3",
+            apiKey: null);
+        var generator = _resolver.CreateEmbeddingGenerator(provider);
+        var metadata = Assert.IsType<EmbeddingGeneratorMetadata>(
+            generator.GetService(typeof(EmbeddingGeneratorMetadata)));
+
+        Assert.Equal(new Uri("http://localhost:8000/v1"), metadata.ProviderUri);
     }
 
     [Fact]

--- a/lucia.Tests/Services/ModelProviderResolverTests.cs
+++ b/lucia.Tests/Services/ModelProviderResolverTests.cs
@@ -127,7 +127,7 @@ public sealed class ModelProviderResolverTests
     {
         var provider = MakeProvider(
             ProviderType.LlamaCpp,
-            endpoint: "http://localhost:8000/llama",
+            endpoint: "http://localhost:8000/llama/V1",
             model: "qwen3.5-9b",
             apiKey: "");
         using var client = _resolver.CreateClient(provider);

--- a/lucia.Tests/Services/ModelProviderResolverTests.cs
+++ b/lucia.Tests/Services/ModelProviderResolverTests.cs
@@ -29,6 +29,14 @@ public sealed class ModelProviderResolverTests
             serviceProvider);
     }
 
+    [Fact]
+    public void ProviderType_ExistingNumericValuesRemainStable()
+    {
+        Assert.Equal(2, (int)ProviderType.AzureOpenAI);
+        Assert.Equal(7, (int)ProviderType.GitHubCopilot);
+        Assert.Equal(8, (int)ProviderType.LlamaCpp);
+    }
+
     #region Helpers
 
     private static ModelProvider MakeProvider(

--- a/lucia.Tests/Services/ProviderModelCatalogServiceTests.cs
+++ b/lucia.Tests/Services/ProviderModelCatalogServiceTests.cs
@@ -210,6 +210,22 @@ public sealed class ProviderModelCatalogServiceTests
     }
 
     [Fact]
+    public async Task ListModelsAsync_LlamaCppMalformedEndpoint_ReturnsValidationError()
+    {
+        var service = new ProviderModelCatalogService(
+            A.Fake<IHttpClientFactory>(),
+            NullLogger<ProviderModelCatalogService>.Instance);
+
+        var result = await service.ListModelsAsync(
+            ProviderType.LlamaCpp,
+            "not a URL",
+            auth: null);
+
+        Assert.Contains("Invalid", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(result.Models);
+    }
+
+    [Fact]
     public async Task ListModelsAsync_OpenAiCompatibleUnauthorized_ReturnsExplicitAuthError()
     {
         var httpFactory = A.Fake<IHttpClientFactory>();

--- a/lucia.Tests/Services/ProviderModelCatalogServiceTests.cs
+++ b/lucia.Tests/Services/ProviderModelCatalogServiceTests.cs
@@ -181,6 +181,31 @@ public sealed class ProviderModelCatalogServiceTests
     }
 
     [Fact]
+    public async Task ListModelsAsync_LlamaCppRootEndpoint_UsesV1ModelsUrl()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        var httpFactory = A.Fake<IHttpClientFactory>();
+        A.CallTo(() => httpFactory.CreateClient("ProviderModelCatalog"))
+            .Returns(new HttpClient(new FakeHttpMessageHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{ "data": [] }""", Encoding.UTF8, "application/json")
+                };
+            })));
+
+        var service = new ProviderModelCatalogService(httpFactory, NullLogger<ProviderModelCatalogService>.Instance);
+        var provider = BuildProvider(ProviderType.LlamaCpp, endpoint: "http://localhost:8000/", apiKey: null);
+
+        var result = await service.ListModelsAsync(provider);
+
+        Assert.Null(result.Error);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("http://localhost:8000/v1/models", capturedRequest!.RequestUri!.ToString());
+    }
+
+    [Fact]
     public async Task ListModelsAsync_OpenAiCompatibleUnauthorized_ReturnsExplicitAuthError()
     {
         var httpFactory = A.Fake<IHttpClientFactory>();

--- a/lucia.Tests/Services/ProviderModelCatalogServiceTests.cs
+++ b/lucia.Tests/Services/ProviderModelCatalogServiceTests.cs
@@ -180,8 +180,12 @@ public sealed class ProviderModelCatalogServiceTests
         Assert.Equal("https://api.openai.com/v1/models", capturedRequest!.RequestUri!.ToString());
     }
 
-    [Fact]
-    public async Task ListModelsAsync_LlamaCppRootEndpoint_UsesV1ModelsUrl()
+    [Theory]
+    [InlineData("http://localhost:8000/", "http://localhost:8000/v1/models")]
+    [InlineData("http://localhost:8000/llama", "http://localhost:8000/llama/v1/models")]
+    public async Task ListModelsAsync_LlamaCppEndpoint_UsesV1ModelsUrl(
+        string endpoint,
+        string expectedModelsEndpoint)
     {
         HttpRequestMessage? capturedRequest = null;
         var httpFactory = A.Fake<IHttpClientFactory>();
@@ -196,13 +200,13 @@ public sealed class ProviderModelCatalogServiceTests
             })));
 
         var service = new ProviderModelCatalogService(httpFactory, NullLogger<ProviderModelCatalogService>.Instance);
-        var provider = BuildProvider(ProviderType.LlamaCpp, endpoint: "http://localhost:8000/", apiKey: null);
+        var provider = BuildProvider(ProviderType.LlamaCpp, endpoint: endpoint, apiKey: null);
 
         var result = await service.ListModelsAsync(provider);
 
         Assert.Null(result.Error);
         Assert.NotNull(capturedRequest);
-        Assert.Equal("http://localhost:8000/v1/models", capturedRequest!.RequestUri!.ToString());
+        Assert.Equal(expectedModelsEndpoint, capturedRequest!.RequestUri!.ToString());
     }
 
     [Fact]

--- a/lucia.Tests/TestDoubles/SnapshotEntityLocationService.cs
+++ b/lucia.Tests/TestDoubles/SnapshotEntityLocationService.cs
@@ -131,6 +131,26 @@ internal sealed class SnapshotEntityLocationService : IEntityLocationService
         return Task.FromResult(SearchHierarchySync(query, domainFilter));
     }
 
+    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
+        string query,
+        HybridMatchOptions? options,
+        IReadOnlyList<string>? domainFilter,
+        string? callerAgentId,
+        CancellationToken ct = default)
+    {
+        var result = await SearchHierarchyAsync(query, options, domainFilter, ct).ConfigureAwait(false);
+        if (callerAgentId is null)
+            return result;
+
+        return result with
+        {
+            ResolvedEntities = result.ResolvedEntities
+                .Where(entity => entity.IncludeForAgent is null
+                    || entity.IncludeForAgent.Contains(callerAgentId))
+                .ToList()
+        };
+    }
+
     public Task<IReadOnlyList<EntityMatchResult<HomeAssistantEntity>>> SearchEntitiesAsync(
         string query, IReadOnlyList<string>? domainFilter = null,
         HybridMatchOptions? options = null, CancellationToken ct = default)

--- a/lucia.Tests/TestDoubles/SnapshotEntityLocationService.cs
+++ b/lucia.Tests/TestDoubles/SnapshotEntityLocationService.cs
@@ -131,26 +131,6 @@ internal sealed class SnapshotEntityLocationService : IEntityLocationService
         return Task.FromResult(SearchHierarchySync(query, domainFilter));
     }
 
-    public async Task<HierarchicalSearchResult> SearchHierarchyAsync(
-        string query,
-        HybridMatchOptions? options,
-        IReadOnlyList<string>? domainFilter,
-        string? callerAgentId,
-        CancellationToken ct = default)
-    {
-        var result = await SearchHierarchyAsync(query, options, domainFilter, ct).ConfigureAwait(false);
-        if (callerAgentId is null)
-            return result;
-
-        return result with
-        {
-            ResolvedEntities = result.ResolvedEntities
-                .Where(entity => entity.IncludeForAgent is null
-                    || entity.IncludeForAgent.Contains(callerAgentId))
-                .ToList()
-        };
-    }
-
     public Task<IReadOnlyList<EntityMatchResult<HomeAssistantEntity>>> SearchEntitiesAsync(
         string query, IReadOnlyList<string>? domainFilter = null,
         HybridMatchOptions? options = null, CancellationToken ct = default)

--- a/lucia.Tests/Wyoming/ClimateCommandPatternTests.cs
+++ b/lucia.Tests/Wyoming/ClimateCommandPatternTests.cs
@@ -1,0 +1,38 @@
+using FakeItEasy;
+using lucia.Agents.Abstractions;
+using lucia.Agents.Configuration.UserConfiguration;
+using lucia.Agents.Services;
+using lucia.Agents.Skills;
+using lucia.HomeAssistant.Services;
+using lucia.Wyoming.CommandRouting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace lucia.Tests.Wyoming;
+
+public sealed class ClimateCommandPatternTests
+{
+    [Fact]
+    public void SetAreaToTemperature_MatchesClimateFastPath()
+    {
+        var skill = new ClimateControlSkill(
+            A.Fake<IHomeAssistantClient>(),
+            A.Fake<IEmbeddingProviderResolver>(),
+            NullLogger<ClimateControlSkill>.Instance,
+            A.Fake<IDeviceCacheService>(),
+            A.Fake<IEntityLocationService>(),
+            A.Fake<IHybridEntityMatcher>(),
+            A.Fake<IOptionsMonitor<ClimateControlSkillOptions>>(),
+            new ConfigurationBuilder().Build());
+        var matcher = new CommandPatternMatcher(new CommandPatternRegistry([skill]));
+
+        var result = matcher.Match("Set the office to 73.");
+
+        Assert.True(result.IsMatch);
+        Assert.Equal("ClimateControlSkill", result.MatchedPattern!.SkillId);
+        Assert.Equal("office", result.CapturedValues!["entity"]);
+        Assert.Equal("73", result.CapturedValues["value"]);
+        Assert.True(result.Confidence >= result.MatchedPattern.MinConfidence);
+    }
+}

--- a/lucia.Tests/Wyoming/ClimateCommandPatternTests.cs
+++ b/lucia.Tests/Wyoming/ClimateCommandPatternTests.cs
@@ -13,8 +13,11 @@ namespace lucia.Tests.Wyoming;
 
 public sealed class ClimateCommandPatternTests
 {
-    [Fact]
-    public void SetAreaToTemperature_MatchesClimateFastPath()
+    [Theory]
+    [InlineData("Set the office to 73.", "73")]
+    [InlineData("Set the office to 72.5.", "72.5")]
+    [InlineData("Set the office to -5.", "-5")]
+    public void SetAreaToTemperature_MatchesClimateFastPath(string input, string expectedTemperature)
     {
         var skill = new ClimateControlSkill(
             A.Fake<IHomeAssistantClient>(),
@@ -27,12 +30,12 @@ public sealed class ClimateCommandPatternTests
             new ConfigurationBuilder().Build());
         var matcher = new CommandPatternMatcher(new CommandPatternRegistry([skill]));
 
-        var result = matcher.Match("Set the office to 73.");
+        var result = matcher.Match(input);
 
         Assert.True(result.IsMatch);
         Assert.Equal("ClimateControlSkill", result.MatchedPattern!.SkillId);
         Assert.Equal("office", result.CapturedValues!["entity"]);
-        Assert.Equal("73", result.CapturedValues["value"]);
+        Assert.Equal(expectedTemperature, result.CapturedValues["value"]);
         Assert.True(result.Confidence >= result.MatchedPattern.MinConfidence);
     }
 }

--- a/lucia.Tests/Wyoming/ClimateCommandPatternTests.cs
+++ b/lucia.Tests/Wyoming/ClimateCommandPatternTests.cs
@@ -17,6 +17,7 @@ public sealed class ClimateCommandPatternTests
     [InlineData("Set the office to 73.", "73")]
     [InlineData("Set the office to 72.5.", "72.5")]
     [InlineData("Set the office to -5.", "-5")]
+    [InlineData("Set the office to (-.5).", "-.5")]
     public void SetAreaToTemperature_MatchesClimateFastPath(string input, string expectedTemperature)
     {
         var skill = new ClimateControlSkill(

--- a/lucia.Tests/Wyoming/CommandPatternMatcherTests.cs
+++ b/lucia.Tests/Wyoming/CommandPatternMatcherTests.cs
@@ -227,6 +227,7 @@ public sealed class CommandPatternMatcherTests
     [InlineData("turn on the garage lights")]
     [InlineData("turn off the garage light")]
     [InlineData("turn on the fan light")]
+    [InlineData("turn off Zach's light")]
     public void LightDevice_StillMatchesLightPattern(string transcript)
     {
         var matcher = CreateMatcher(LightPattern);

--- a/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
+++ b/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
@@ -38,6 +38,7 @@ public sealed class TranscriptNormalizerTests
     [InlineData("Set kitchen-light to 72.5.", "set kitchen light to 72.5")]
     [InlineData("Set the thermostat to -5.", "set the thermostat to -5")]
     [InlineData("Set the thermostat to (-5).", "set the thermostat to -5")]
+    [InlineData("Set the thermostat to (-.5).", "set the thermostat to -.5")]
     public void Normalize_PreservesNumericPunctuationAndSeparatesWords(string input, string expected)
     {
         Assert.Equal(expected, TranscriptNormalizer.Normalize(input));

--- a/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
+++ b/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
@@ -17,6 +17,7 @@ public sealed class TranscriptNormalizerTests
     [InlineData("uh like set the thermostat", "set the thermostat")]
     [InlineData("okay actually turn off lights", "turn off lights")]
     [InlineData("you know turn on the lights thank you", "turn on the lights")]
+    [InlineData("you, know turn on the lights", "turn on the lights")]
     public void Normalize_RemovesFillerAndPoliteWords(string input, string expected)
     {
         Assert.Equal(expected, TranscriptNormalizer.Normalize(input));
@@ -89,6 +90,7 @@ public sealed class TranscriptNormalizerTests
 
     [Theory]
     [InlineData("TURN OF THE OFFICE LIGHTS", "turn off the office lights")]
+    [InlineData("turn, of the office lights", "turn off the office lights")]
     [InlineData("turn of the kitchen lights", "turn off the kitchen lights")]
     [InlineData("shut of the bedroom lights", "shut off the bedroom lights")]
     [InlineData("trun on the lights", "turn on the lights")]

--- a/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
+++ b/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
@@ -37,6 +37,7 @@ public sealed class TranscriptNormalizerTests
     [Theory]
     [InlineData("Set kitchen-light to 72.5.", "set kitchen light to 72.5")]
     [InlineData("Set the thermostat to -5.", "set the thermostat to -5")]
+    [InlineData("Set the thermostat to (-5).", "set the thermostat to -5")]
     public void Normalize_PreservesNumericPunctuationAndSeparatesWords(string input, string expected)
     {
         Assert.Equal(expected, TranscriptNormalizer.Normalize(input));

--- a/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
+++ b/lucia.Tests/Wyoming/TranscriptNormalizerTests.cs
@@ -35,6 +35,14 @@ public sealed class TranscriptNormalizerTests
     }
 
     [Theory]
+    [InlineData("Set kitchen-light to 72.5.", "set kitchen light to 72.5")]
+    [InlineData("Set the thermostat to -5.", "set the thermostat to -5")]
+    public void Normalize_PreservesNumericPunctuationAndSeparatesWords(string input, string expected)
+    {
+        Assert.Equal(expected, TranscriptNormalizer.Normalize(input));
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData(null)]
     [InlineData("   ")]

--- a/lucia.Wyoming/CommandRouting/TranscriptNormalizer.cs
+++ b/lucia.Wyoming/CommandRouting/TranscriptNormalizer.cs
@@ -68,6 +68,7 @@ public static partial class TranscriptNormalizer
 
         var result = transcript.ToLowerInvariant().Trim();
         result = CommandTextNormalizer.NormalizePunctuation(result);
+        result = MultipleSpaces().Replace(result, " ").Trim();
 
         // Apply phrase-level STT corrections before word filtering
         foreach (var (pattern, replacement) in PhraseCorrections)

--- a/lucia.Wyoming/CommandRouting/TranscriptNormalizer.cs
+++ b/lucia.Wyoming/CommandRouting/TranscriptNormalizer.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using System.Text.RegularExpressions;
+using lucia.Agents.Integration;
 
 namespace lucia.Wyoming.CommandRouting;
 
@@ -67,7 +67,7 @@ public static partial class TranscriptNormalizer
             return string.Empty;
 
         var result = transcript.ToLowerInvariant().Trim();
-        result = NormalizePunctuation(result);
+        result = CommandTextNormalizer.NormalizePunctuation(result);
 
         // Apply phrase-level STT corrections before word filtering
         foreach (var (pattern, replacement) in PhraseCorrections)
@@ -89,36 +89,6 @@ public static partial class TranscriptNormalizer
         result = string.Join(' ', words);
 
         return result;
-    }
-
-    private static string NormalizePunctuation(string value)
-    {
-        var result = new StringBuilder(value.Length);
-        for (var index = 0; index < value.Length; index++)
-        {
-            var character = value[index];
-            if (char.IsLetterOrDigit(character)
-                || char.IsWhiteSpace(character)
-                || character == '_')
-            {
-                result.Append(character);
-                continue;
-            }
-
-            var isDecimalPoint = character == '.'
-                && index > 0
-                && index < value.Length - 1
-                && char.IsDigit(value[index - 1])
-                && char.IsDigit(value[index + 1]);
-            var isNumericSign = character is '-' or '+'
-                && index < value.Length - 1
-                && char.IsDigit(value[index + 1])
-                && (index == 0 || char.IsWhiteSpace(value[index - 1]));
-
-            result.Append(isDecimalPoint || isNumericSign ? character : ' ');
-        }
-
-        return result.ToString();
     }
 
     /// <summary>

--- a/lucia.Wyoming/CommandRouting/TranscriptNormalizer.cs
+++ b/lucia.Wyoming/CommandRouting/TranscriptNormalizer.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace lucia.Wyoming.CommandRouting;
@@ -57,9 +58,6 @@ public static partial class TranscriptNormalizer
     [GeneratedRegex(@"\s+")]
     private static partial Regex MultipleSpaces();
 
-    [GeneratedRegex(@"[^\w\s]")]
-    private static partial Regex Punctuation();
-
     /// <summary>
     /// Normalize transcript for pattern matching.
     /// </summary>
@@ -69,7 +67,7 @@ public static partial class TranscriptNormalizer
             return string.Empty;
 
         var result = transcript.ToLowerInvariant().Trim();
-        result = Punctuation().Replace(result, "");
+        result = NormalizePunctuation(result);
 
         // Apply phrase-level STT corrections before word filtering
         foreach (var (pattern, replacement) in PhraseCorrections)
@@ -91,6 +89,36 @@ public static partial class TranscriptNormalizer
         result = string.Join(' ', words);
 
         return result;
+    }
+
+    private static string NormalizePunctuation(string value)
+    {
+        var result = new StringBuilder(value.Length);
+        for (var index = 0; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (char.IsLetterOrDigit(character)
+                || char.IsWhiteSpace(character)
+                || character == '_')
+            {
+                result.Append(character);
+                continue;
+            }
+
+            var isDecimalPoint = character == '.'
+                && index > 0
+                && index < value.Length - 1
+                && char.IsDigit(value[index - 1])
+                && char.IsDigit(value[index + 1]);
+            var isNumericSign = character is '-' or '+'
+                && index < value.Length - 1
+                && char.IsDigit(value[index + 1])
+                && (index == 0 || char.IsWhiteSpace(value[index - 1]));
+
+            result.Append(isDecimalPoint || isNumericSign ? character : ' ');
+        }
+
+        return result.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- treat unresolved locations as entity candidates and retry deterministic misses through configured embeddings
- add an explicit llama.cpp provider while preserving existing OpenAI endpoint behavior
- strengthen climate `set` patterns so commands such as `Set the office to 73` clear the fast-path confidence threshold
- document llama.cpp provider support

## Validation
- provider-free pre-push suite: 1,410 tests passed
- dashboard production build passed
- live llama.cpp embedding check returned 1,024 dimensions
- Jetson health, CUDA, and telemetry deployment gates passed