### PR TITLE
ci(appliance): prebuild Jetson voice assets

### DIFF
--- a/.github/workflows/appliance-release.yml
+++ b/.github/workflows/appliance-release.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   contents: write
-  packages: write
+  packages: read
   id-token: write
   attestations: write
 
@@ -23,7 +23,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release-tag:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      - name: Validate release tag
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
   voice-assets:
+    needs: validate-release-tag
     uses: ./.github/workflows/jetson-voice-assets.yml
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
@@ -33,7 +47,7 @@ jobs:
 
   build-and-publish:
     name: Build and publish appliance assets
-    needs: voice-assets
+    needs: [validate-release-tag, voice-assets]
     runs-on: [self-hosted, Linux, X64, jetson-image-builder]
     timeout-minutes: 720
     defaults:
@@ -45,13 +59,6 @@ jobs:
       VOICE_ASSET_REF: ${{ needs.voice-assets.outputs.image_ref }}
 
     steps:
-      - name: Validate release tag
-        run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag must match vMAJOR.MINOR.PATCH"
-            exit 1
-          fi
-
       - name: Check out release
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -247,5 +254,5 @@ jobs:
           sudo rm -rf --one-file-system -- \
             "$work_dir" \
             "$GITHUB_WORKSPACE/dist"
-          docker image rm "lucia-appliance-voice-assets:$version" \
+          docker image rm "$VOICE_ASSET_REF" \
             >/dev/null 2>&1 || true

--- a/.github/workflows/appliance-release.yml
+++ b/.github/workflows/appliance-release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
   id-token: write
   attestations: write
 
@@ -22,15 +23,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  voice-assets:
+    uses: ./.github/workflows/jetson-voice-assets.yml
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+    permissions:
+      contents: read
+      packages: write
+
   build-and-publish:
     name: Build and publish appliance assets
+    needs: voice-assets
     runs-on: [self-hosted, Linux, X64, jetson-image-builder]
-    timeout-minutes: 360
+    timeout-minutes: 720
     defaults:
       run:
         shell: bash
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      VOICE_ASSET_IMAGE: ghcr.io/${{ github.repository }}/jetson-voice-assets
+      VOICE_ASSET_REF: ${{ needs.voice-assets.outputs.image_ref }}
 
     steps:
       - name: Validate release tag
@@ -68,8 +80,12 @@ jobs:
         with:
           platforms: arm64
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify dedicated runner
         run: |

--- a/.github/workflows/jetson-voice-assets.yml
+++ b/.github/workflows/jetson-voice-assets.yml
@@ -1,0 +1,115 @@
+name: Build Jetson Voice Assets
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'infra/docker/Dockerfile.agenthost-jetson-voice'
+      - '.github/workflows/jetson-voice-assets.yml'
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref containing the voice asset inputs
+        required: true
+        type: string
+    outputs:
+      image_ref:
+        description: Immutable Jetson voice asset image reference
+        value: ${{ jobs.build.outputs.image_ref }}
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: jetson-voice-assets
+  cancel-in-progress: false
+
+env:
+  VOICE_ASSET_IMAGE: ghcr.io/${{ github.repository }}/jetson-voice-assets
+
+jobs:
+  build:
+    name: Build Jetson voice assets
+    runs-on: [self-hosted, Linux, X64, jetson-image-builder]
+    timeout-minutes: 720
+    outputs:
+      image_ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Compute immutable image tag
+        id: image
+        run: |
+          hash="$(sha256sum infra/docker/Dockerfile.agenthost-jetson-voice | cut -d' ' -f1)"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+          echo "ref=$VOICE_ASSET_IMAGE:sha-$hash" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for existing image
+        id: existing
+        run: |
+          if docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up ARM64 emulation
+        if: steps.existing.outputs.found != 'true'
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        if: steps.existing.outputs.found != 'true'
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        with:
+          name: jetson-voice-builder
+          keep-state: true
+          cleanup: false
+
+      - name: Build and publish voice assets
+        id: build
+        if: steps.existing.outputs.found != 'true'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.agenthost-jetson-voice
+          target: appliance-voice-assets
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.image.outputs.ref }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Resolve immutable image reference
+        id: resolve
+        run: |
+          digest="$(
+            docker buildx imagetools inspect \
+              "${{ steps.image.outputs.ref }}" \
+              --format '{{json .Manifest.Digest}}' \
+              | tr -d '"'
+          )"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          echo "ref=$VOICE_ASSET_IMAGE@$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize image
+        run: |
+          {
+            echo "### Jetson voice assets"
+            echo
+            echo "- Image: \`${{ steps.resolve.outputs.ref }}\`"
+            echo "- Existing image reused: \`${{ steps.existing.outputs.found }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/jetson-voice-assets.yml
+++ b/.github/workflows/jetson-voice-assets.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
     paths:
       - 'infra/docker/Dockerfile.agenthost-jetson-voice'
+      - 'infra/appliance/release/voice-asset-key.sh'
       - '.github/workflows/jetson-voice-assets.yml'
   workflow_dispatch:
   workflow_call:
@@ -45,7 +46,7 @@ jobs:
       - name: Compute immutable image tag
         id: image
         run: |
-          hash="$(sha256sum infra/docker/Dockerfile.agenthost-jetson-voice | cut -d' ' -f1)"
+          hash="$(bash infra/appliance/release/voice-asset-key.sh)"
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
           echo "ref=$VOICE_ASSET_IMAGE:sha-$hash" >> "$GITHUB_OUTPUT"
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,100 @@
+# Release notes - 1.4.0
+
+**Release date:** September 1, 2026
+
+---
+
+## Overview
+
+Version 1.4.0 ships Lucia's first official appliance image for the NVIDIA
+Jetson Orin Nano Super 8GB Developer Kit. It installs a native, Docker-free
+Lucia system from microSD to NVMe, including local voice models, CUDA runtime
+support, Redis, SQLite, the dashboard, and appliance management.
+
+This release also restores deterministic command routing for unresolved entity
+names and adds explicit llama.cpp provider support.
+
+## Appliance image
+
+- Install from a flashable microSD image onto an NVMe drive of at least
+  61,203,283,968 bytes. The installer binds erase approval to the selected
+  drive's stable identity and image digest before writing it.
+- Run Jetson Linux 36.5.2 from A/B operating-system slots, with separate
+  partitions for versioned Lucia files and persistent application data.
+- Complete setup through a client-isolated captive network. The first browser
+  claims the setup session, selects Wi-Fi, chooses the hostname and recovery
+  password, and receives the dashboard API key.
+- Recover from a failed Wi-Fi activation without reprovisioning. The installer
+  rolls back the NetworkManager checkpoint and restores setup mode.
+- Use the native Jetson GPU for Lucia's bundled speech models. The image
+  includes the pinned ARM64 ONNX Runtime, CUDA provider, sherpa-onnx libraries,
+  and voice assets needed for offline setup.
+- Open the installed dashboard at `https://HOSTNAME.local:8099`. Each appliance
+  creates its own certificate during setup, so the first browser must accept
+  the local certificate.
+
+See the [appliance release guide](infra/appliance/release/README.md) for the
+asset layout and release details. ([#257](https://github.com/seiggy/lucia-dotnet/pull/257))
+
+## Appliance management and telemetry
+
+- View appliance, storage, service, Wi-Fi, and operating-system status from the
+  dashboard.
+- Restart Lucia services or reboot the appliance through the authenticated
+  AgentHost adapter and root-owned appliance manager.
+- Configure authenticated OTLP export without exposing telemetry credentials
+  in appliance status responses.
+- Run the OpenTelemetry Collector and Redis exporter when remote telemetry is
+  enabled. Both remain disabled by default.
+- Discover compatible Lucia and operating-system releases from GitHub.
+  Installing discovered updates remains locked in this release.
+
+## Release integrity
+
+- Stable releases publish separate installer, Lucia, and operating-system
+  channels.
+- Large images are split into GitHub Release parts below the 2 GB asset limit.
+- `lucia-appliance-manifest.json` records compatibility, sizes, SHA-256 hashes,
+  ordered parts, and download URLs.
+- GitHub build-provenance attestations cover every release asset. The workflow
+  uploads the manifest last so an incomplete release cannot be discovered by
+  an appliance.
+
+## Command routing
+
+- Retry unresolved locations as entity names through the configured embedding
+  provider instead of dropping out of the deterministic command path.
+- Recognize direct climate commands such as "Set the office to 73" with enough
+  confidence to use the fast path.
+- Add an explicit llama.cpp provider while preserving existing OpenAI-compatible
+  endpoint behavior. ([#256](https://github.com/seiggy/lucia-dotnet/pull/256))
+
+## Read before installing
+
+- The image supports the Jetson Orin Nano Super Developer Kit with the 8GB
+  P3767-0005 module. Other Jetson boards and carrier configurations are not
+  supported by this release.
+- Installation erases the selected NVMe drive after explicit confirmation.
+  Keep the appliance physically controlled while its open setup network is
+  active.
+- The dashboard can discover updates but cannot install them yet. Attestation
+  verification, application rollback, and NVIDIA A/B OTA apply are still in
+  progress.
+- Automatic QSPI compatibility reporting, full occupied-drive layout
+  reporting, physical power-cut recovery, secure boot, and disk encryption are
+  not included in v1.4.0.
+
+## Breaking changes
+
+None. Appliance mode defaults to `Off`, so Docker and other existing
+deployments keep their current routes and behavior.
+
+## Full changelog
+
+[v1.3.1...v1.4.0](https://github.com/seiggy/lucia-dotnet/compare/v1.3.1...v1.4.0)
+
+---
+
 # Release notes - 1.3.0
 
 **Release date:** August 21, 2026

--- a/infra/appliance/release/README.md
+++ b/infra/appliance/release/README.md
@@ -82,8 +82,8 @@ used only on the build runner; the installed appliance runs native services.
 `.github/workflows/jetson-voice-assets.yml` rebuilds that image only when its
 pinned Dockerfile inputs change. Appliance releases invoke that workflow first
 and consume the exact returned image digest. Its named Buildx builder retains
-partial compilation state across failed or timed-out runs on the dedicated
-runner.
+completed build layers across failed or timed-out runs on the dedicated runner.
+An interrupted compile step still restarts from the beginning.
 
 The image build is unsuitable for a standard GitHub-hosted runner because the
 two Jetson rootfs trees, signed flash package, raw images, voice build, and

--- a/infra/appliance/release/README.md
+++ b/infra/appliance/release/README.md
@@ -76,6 +76,15 @@ The runner must have:
 - .NET 10, Node 22, and Python 3.12, installed by the workflow;
 - direct internet access to NVIDIA, Ubuntu, NuGet, npm, GitHub, and GHCR.
 
+The release downloads the pinned Jetson voice asset image from GHCR and
+extracts its native libraries and models into the Lucia payload. Docker is
+used only on the build runner; the installed appliance runs native services.
+`.github/workflows/jetson-voice-assets.yml` rebuilds that image only when its
+pinned Dockerfile inputs change. Appliance releases invoke that workflow first
+and consume the exact returned image digest. Its named Buildx builder retains
+partial compilation state across failed or timed-out runs on the dedicated
+runner.
+
 The image build is unsuitable for a standard GitHub-hosted runner because the
 two Jetson rootfs trees, signed flash package, raw images, voice build, and
 compressed outputs exceed its disk allowance.
@@ -94,8 +103,10 @@ Manual runs require an existing stable tag and GitHub Release.
 python3 infra/appliance/release/test_package_release.py
 bash infra/appliance/release/test_build_release_assets.sh
 bash -n infra/appliance/release/build-release-assets.sh
+act -l -W .github/workflows/jetson-voice-assets.yml
 act -l -W .github/workflows/appliance-release.yml
 ```
 
 The complete image build still requires the dedicated Linux runner and roughly
-200 GiB of scratch space.
+200 GiB of scratch space. The first voice asset compilation may take more than
+six hours on older x86-64 hardware; both self-hosted jobs allow up to 12 hours.

--- a/infra/appliance/release/build-release-assets.sh
+++ b/infra/appliance/release/build-release-assets.sh
@@ -192,19 +192,21 @@ tar -xzf \
 [[ -x "$telemetry_dir/redis-exporter/redis_exporter" ]] \
     || die "Redis exporter archive did not contain redis_exporter"
 
-voice_image="lucia-appliance-voice-assets:${version}"
-docker buildx build \
-    --platform linux/arm64 \
-    --load \
-    --tag "$voice_image" \
-    --file "$repo_root/infra/docker/Dockerfile.agenthost-jetson-voice" \
-    "$repo_root"
-voice_container="$(docker create "$voice_image")"
+voice_asset_hash="$(
+    sha256sum "$repo_root/infra/docker/Dockerfile.agenthost-jetson-voice" \
+        | cut -d' ' -f1
+)"
+voice_asset_image="${VOICE_ASSET_IMAGE:-ghcr.io/seiggy/lucia-dotnet/jetson-voice-assets}"
+voice_asset_ref="${VOICE_ASSET_REF:-${voice_asset_image}:sha-${voice_asset_hash}}"
+docker pull --platform linux/arm64 "$voice_asset_ref"
+voice_container="$(
+    docker create --platform linux/arm64 "$voice_asset_ref" /bin/true
+)"
 trap 'docker rm -f "$voice_container" >/dev/null 2>&1 || true' EXIT
-mkdir -p "$voice_dir"
-docker cp "$voice_container:/app/runtimes/linux-arm64/native" "$voice_dir/native"
-docker cp "$voice_container:/app/models" "$voice_dir/models"
-docker cp "$voice_container:/app/plugins" "$voice_dir/plugins"
+mkdir -p "$voice_dir/native" "$voice_dir/models" "$voice_dir/plugins"
+docker cp "$voice_container:/native/." "$voice_dir/native/"
+docker cp "$voice_container:/models/." "$voice_dir/models/"
+cp -a "$repo_root/plugins/." "$voice_dir/plugins/"
 docker rm "$voice_container" >/dev/null
 trap - EXIT
 

--- a/infra/appliance/release/build-release-assets.sh
+++ b/infra/appliance/release/build-release-assets.sh
@@ -192,10 +192,7 @@ tar -xzf \
 [[ -x "$telemetry_dir/redis-exporter/redis_exporter" ]] \
     || die "Redis exporter archive did not contain redis_exporter"
 
-voice_asset_hash="$(
-    sha256sum "$repo_root/infra/docker/Dockerfile.agenthost-jetson-voice" \
-        | cut -d' ' -f1
-)"
+voice_asset_hash="$(bash "$script_dir/voice-asset-key.sh")"
 voice_asset_image="${VOICE_ASSET_IMAGE:-ghcr.io/seiggy/lucia-dotnet/jetson-voice-assets}"
 voice_asset_ref="${VOICE_ASSET_REF:-${voice_asset_image}:sha-${voice_asset_hash}}"
 docker pull --platform linux/arm64 "$voice_asset_ref"

--- a/infra/appliance/release/test_build_release_assets.sh
+++ b/infra/appliance/release/test_build_release_assets.sh
@@ -24,5 +24,25 @@ grep -q 'gpasswd --delete lucia-recovery sudo' \
     "$script_dir/build-release-assets.sh"
 grep -q 'usermod --shell.*lucia-recovery' \
     "$script_dir/build-release-assets.sh"
+grep -q '^FROM scratch AS appliance-voice-assets$' \
+    "$script_dir/../../docker/Dockerfile.agenthost-jetson-voice"
+grep -q 'docker pull --platform linux/arm64 "$voice_asset_ref"' \
+    "$script_dir/build-release-assets.sh"
+! grep -q 'docker buildx build' \
+    "$script_dir/build-release-assets.sh"
+grep -q 'cp -a "$repo_root/plugins/." "$voice_dir/plugins/"' \
+    "$script_dir/build-release-assets.sh"
+grep -q 'target: appliance-voice-assets' \
+    "$script_dir/../../../.github/workflows/jetson-voice-assets.yml"
+grep -q 'keep-state: true' \
+    "$script_dir/../../../.github/workflows/jetson-voice-assets.yml"
+grep -q 'timeout-minutes: 720' \
+    "$script_dir/../../../.github/workflows/jetson-voice-assets.yml"
+grep -q 'needs: voice-assets' \
+    "$script_dir/../../../.github/workflows/appliance-release.yml"
+grep -q 'ref:.*inputs.tag.*github.ref' \
+    "$script_dir/../../../.github/workflows/appliance-release.yml"
+grep -q 'VOICE_ASSET_REF:.*needs.voice-assets.outputs.image_ref' \
+    "$script_dir/../../../.github/workflows/appliance-release.yml"
 
 echo "PASS: release rootfs uses pinned packages and restricted recovery"

--- a/infra/appliance/release/test_build_release_assets.sh
+++ b/infra/appliance/release/test_build_release_assets.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$script_dir/appliance.lock"
+voice_dockerfile="$script_dir/../../docker/Dockerfile.agenthost-jetson-voice"
+voice_key_script="$script_dir/voice-asset-key.sh"
+workflow_dir="$script_dir/../../../.github/workflows"
 
 [[ "${#COMPUTE_PACKAGES[@]}" -eq 8 ]]
 [[ "$JETSON_BSP_SHA256" =~ ^[0-9a-f]{64}$ ]]
@@ -25,24 +28,44 @@ grep -q 'gpasswd --delete lucia-recovery sudo' \
 grep -q 'usermod --shell.*lucia-recovery' \
     "$script_dir/build-release-assets.sh"
 grep -q '^FROM scratch AS appliance-voice-assets$' \
-    "$script_dir/../../docker/Dockerfile.agenthost-jetson-voice"
+    "$voice_dockerfile"
 grep -q 'docker pull --platform linux/arm64 "$voice_asset_ref"' \
     "$script_dir/build-release-assets.sh"
 ! grep -q 'docker buildx build' \
     "$script_dir/build-release-assets.sh"
+grep -q 'voice-asset-key.sh' \
+    "$script_dir/build-release-assets.sh" \
+    "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'cp -a "$repo_root/plugins/." "$voice_dir/plugins/"' \
     "$script_dir/build-release-assets.sh"
 grep -q 'target: appliance-voice-assets' \
-    "$script_dir/../../../.github/workflows/jetson-voice-assets.yml"
+    "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'keep-state: true' \
-    "$script_dir/../../../.github/workflows/jetson-voice-assets.yml"
+    "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'timeout-minutes: 720' \
-    "$script_dir/../../../.github/workflows/jetson-voice-assets.yml"
-grep -q 'needs: voice-assets' \
-    "$script_dir/../../../.github/workflows/appliance-release.yml"
+    "$workflow_dir/jetson-voice-assets.yml"
+grep -q '^  validate-release-tag:' \
+    "$workflow_dir/appliance-release.yml"
+grep -q 'needs: validate-release-tag' \
+    "$workflow_dir/appliance-release.yml"
+grep -q 'needs: \[validate-release-tag, voice-assets\]' \
+    "$workflow_dir/appliance-release.yml"
 grep -q 'ref:.*inputs.tag.*github.ref' \
-    "$script_dir/../../../.github/workflows/appliance-release.yml"
+    "$workflow_dir/appliance-release.yml"
 grep -q 'VOICE_ASSET_REF:.*needs.voice-assets.outputs.image_ref' \
-    "$script_dir/../../../.github/workflows/appliance-release.yml"
+    "$workflow_dir/appliance-release.yml"
+sed -n '15,20p' "$workflow_dir/appliance-release.yml" \
+    | grep -q '^  packages: read$'
+grep -q 'docker image rm "$VOICE_ASSET_REF"' \
+    "$workflow_dir/appliance-release.yml"
+
+voice_fixture="$(mktemp)"
+trap 'rm -f "$voice_fixture"' EXIT
+cp "$voice_dockerfile" "$voice_fixture"
+voice_key="$(bash "$voice_key_script" "$voice_fixture")"
+sed -i 's/node:22-alpine/node:22-alpine3.21/' "$voice_fixture"
+[[ "$(bash "$voice_key_script" "$voice_fixture")" == "$voice_key" ]]
+sed -i 's/ARG ORT_VERSION=1.23.2/ARG ORT_VERSION=1.23.3/' "$voice_fixture"
+[[ "$(bash "$voice_key_script" "$voice_fixture")" != "$voice_key" ]]
 
 echo "PASS: release rootfs uses pinned packages and restricted recovery"

--- a/infra/appliance/release/voice-asset-key.sh
+++ b/infra/appliance/release/voice-asset-key.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dockerfile="${1:-$script_dir/../../docker/Dockerfile.agenthost-jetson-voice}"
+
+awk '
+    found && /^FROM / { exit }
+    { print }
+    /^FROM scratch AS appliance-voice-assets$/ { found = 1 }
+    END { if (!found) exit 1 }
+' "$dockerfile" | sha256sum | cut -d' ' -f1

--- a/infra/docker/Dockerfile.agenthost-jetson-voice
+++ b/infra/docker/Dockerfile.agenthost-jetson-voice
@@ -290,6 +290,12 @@ RUN mkdir -p /assets/models/speech-enhancement/gtcrn_simple \
           /assets/models/speech-enhancement/gtcrn_simple/gtcrn_simple.onnx \
           b4718df6228e7bdf1a8a435cf98f838636eb2fd331acabf86ba87c5192ebcb87
 
+# Build-only artifact consumed by native appliance releases. The target contains
+# no executable container runtime; Docker is only the reproducible ARM64 compiler.
+FROM scratch AS appliance-voice-assets
+COPY --from=sherpa-build /native/ /native/
+COPY --from=model-download /assets/models/ /models/
+
 # ============================================================================
 # Stage: node-build — React SPA dashboard (arch-independent)
 # ============================================================================


### PR DESCRIPTION
## Description

Appliance releases currently compile the ARM64 ONNX Runtime and sherpa-onnx voice stack during every image build, making an already large Jetson release job slower and harder to recover after interruption. This PR publishes those pinned voice assets once as an immutable GHCR image, retains completed BuildKit layers between attempts, and makes appliance releases consume the exact returned digest.

It also adds the v1.4.0 release notes for Lucia's first official Jetson appliance image, including supported hardware, installation behavior, release integrity, and known update limits.

## Type of Change
Please select the relevant options:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/formatting changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ⚡ Performance improvements
- [x] ✅ Test updates
- [x] 🔧 Build/CI changes

## Related Issues
N/A

## Changes Made
- [x] Add a reusable workflow that builds and publishes pinned Jetson voice assets to GHCR.
- [x] Make appliance releases consume the workflow's immutable image digest and allow up to 12 hours for self-hosted builds.
- [x] Validate release tags before package writes, use a target-only asset key, and remove pulled images during cleanup.
- [x] Update release packaging checks, build documentation, and v1.4.0 release notes.

## Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

### Test Environment
- **OS:** Windows 11 with Bash
- **Browser:** N/A
- **Node version:** N/A

## Screenshots/Demo
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes
The first voice asset build may still take more than six hours on older x86-64 hardware. The named builder retains completed layers, but an interrupted compiler step restarts from the beginning.

The existing `v1.4.0` tag predates these commits. Release operators must ensure the final stable tag resolves to the merged commit before dispatching the appliance build.

## Breaking Changes
N/A

## Migration Guide
N/A

---

**For Reviewers:**
- [ ] Code quality and style
- [ ] Functionality works as expected
- [ ] Tests are comprehensive
- [ ] Documentation is updated
- [ ] No security concerns
- [ ] Performance impact is acceptable