### PR TITLE
perf(appliance): build voice assets on native ARM64

### DIFF
--- a/.github/workflows/jetson-voice-assets.yml
+++ b/.github/workflows/jetson-voice-assets.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     name: Build Jetson voice assets
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 720
+    timeout-minutes: 360
     outputs:
       image_ref: ${{ steps.resolve.outputs.ref }}
     steps:

--- a/.github/workflows/jetson-voice-assets.yml
+++ b/.github/workflows/jetson-voice-assets.yml
@@ -8,12 +8,6 @@ on:
       - 'infra/appliance/release/voice-asset-key.sh'
       - '.github/workflows/jetson-voice-assets.yml'
   workflow_dispatch:
-    inputs:
-      benchmark:
-        description: Force a native ARM64 benchmark build with a unique image tag
-        required: false
-        type: boolean
-        default: false
   workflow_call:
     inputs:
       ref:
@@ -30,7 +24,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ inputs.benchmark && format('jetson-voice-benchmark-{0}', github.run_id) || 'jetson-voice-assets' }}
+  group: jetson-voice-assets
   cancel-in-progress: false
 
 env:
@@ -51,16 +45,10 @@ jobs:
 
       - name: Compute immutable image tag
         id: image
-        env:
-          BENCHMARK: ${{ inputs.benchmark }}
         run: |
           hash="$(bash infra/appliance/release/voice-asset-key.sh)"
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
-          if [[ "$BENCHMARK" == "true" ]]; then
-            echo "ref=$VOICE_ASSET_IMAGE:benchmark-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=$VOICE_ASSET_IMAGE:sha-$hash" >> "$GITHUB_OUTPUT"
-          fi
+          echo "ref=$VOICE_ASSET_IMAGE:sha-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -71,12 +59,8 @@ jobs:
 
       - name: Check for existing image
         id: existing
-        env:
-          BENCHMARK: ${{ inputs.benchmark }}
         run: |
-          if [[ "$BENCHMARK" == "true" ]]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          elif docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
+          if docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -121,5 +105,4 @@ jobs:
             echo
             echo "- Image: \`${{ steps.resolve.outputs.ref }}\`"
             echo "- Existing image reused: \`${{ steps.existing.outputs.found }}\`"
-            echo "- Benchmark: \`${{ inputs.benchmark }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/jetson-voice-assets.yml
+++ b/.github/workflows/jetson-voice-assets.yml
@@ -8,6 +8,12 @@ on:
       - 'infra/appliance/release/voice-asset-key.sh'
       - '.github/workflows/jetson-voice-assets.yml'
   workflow_dispatch:
+    inputs:
+      benchmark:
+        description: Force a native ARM64 benchmark build with a unique image tag
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       ref:
@@ -24,7 +30,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: jetson-voice-assets
+  group: ${{ inputs.benchmark && format('jetson-voice-benchmark-{0}', github.run_id) || 'jetson-voice-assets' }}
   cancel-in-progress: false
 
 env:
@@ -33,7 +39,7 @@ env:
 jobs:
   build:
     name: Build Jetson voice assets
-    runs-on: [self-hosted, Linux, X64, jetson-image-builder]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 720
     outputs:
       image_ref: ${{ steps.resolve.outputs.ref }}
@@ -45,10 +51,16 @@ jobs:
 
       - name: Compute immutable image tag
         id: image
+        env:
+          BENCHMARK: ${{ inputs.benchmark }}
         run: |
           hash="$(bash infra/appliance/release/voice-asset-key.sh)"
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
-          echo "ref=$VOICE_ASSET_IMAGE:sha-$hash" >> "$GITHUB_OUTPUT"
+          if [[ "$BENCHMARK" == "true" ]]; then
+            echo "ref=$VOICE_ASSET_IMAGE:benchmark-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$VOICE_ASSET_IMAGE:sha-$hash" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -59,26 +71,20 @@ jobs:
 
       - name: Check for existing image
         id: existing
+        env:
+          BENCHMARK: ${{ inputs.benchmark }}
         run: |
-          if docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
+          if [[ "$BENCHMARK" == "true" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          elif docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up ARM64 emulation
-        if: steps.existing.outputs.found != 'true'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
         if: steps.existing.outputs.found != 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-        with:
-          name: jetson-voice-builder
-          keep-state: true
-          cleanup: false
 
       - name: Build and publish voice assets
         id: build
@@ -93,6 +99,8 @@ jobs:
           tags: ${{ steps.image.outputs.ref }}
           provenance: mode=max
           sbom: true
+          cache-from: type=gha,scope=jetson-voice-assets
+          cache-to: type=gha,scope=jetson-voice-assets,mode=max
 
       - name: Resolve immutable image reference
         id: resolve
@@ -113,4 +121,5 @@ jobs:
             echo
             echo "- Image: \`${{ steps.resolve.outputs.ref }}\`"
             echo "- Existing image reused: \`${{ steps.existing.outputs.found }}\`"
+            echo "- Benchmark: \`${{ inputs.benchmark }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/appliance/release/README.md
+++ b/infra/appliance/release/README.md
@@ -111,5 +111,5 @@ act -l -W .github/workflows/appliance-release.yml
 ```
 
 The complete image build still requires the dedicated Linux runner and roughly
-200 GiB of scratch space. The first voice asset compilation may take more than
-six hours on older x86-64 hardware; both self-hosted jobs allow up to 12 hours.
+200 GiB of scratch space. The GitHub-hosted voice job and self-hosted packaging
+job each allow up to 12 hours.

--- a/infra/appliance/release/README.md
+++ b/infra/appliance/release/README.md
@@ -56,7 +56,8 @@ GitHub Release assets are limited to 2 GiB per file. The packager uses
 
 ## Runner
 
-The workflow requires a dedicated self-hosted runner with these labels:
+The complete appliance build requires a dedicated self-hosted runner with these
+labels:
 
 ```text
 self-hosted
@@ -71,7 +72,7 @@ The runner must have:
 - at least 200 GiB free under `RUNNER_TEMP`;
 - passwordless `sudo`;
 - Docker with Buildx;
-- `qemu-user-static` with `/usr/bin/qemu-aarch64-static`;
+- `qemu-user-static` with `/usr/bin/qemu-aarch64-static` for the Jetson rootfs;
 - GitHub CLI;
 - .NET 10, Node 22, and Python 3.12, installed by the workflow;
 - direct internet access to NVIDIA, Ubuntu, NuGet, npm, GitHub, and GHCR.
@@ -81,12 +82,13 @@ extracts its native libraries and models into the Lucia payload. Docker is
 used only on the build runner; the installed appliance runs native services.
 `.github/workflows/jetson-voice-assets.yml` rebuilds that image only when its
 pinned Dockerfile inputs change. Appliance releases invoke that workflow first
-and consume the exact returned image digest. Its named Buildx builder retains
-completed build layers across failed or timed-out runs on the dedicated runner.
-An interrupted compile step still restarts from the beginning.
+and consume the exact returned image digest. The isolated voice build runs
+natively on GitHub's `ubuntu-24.04-arm` runner and uses the Actions cache for
+completed BuildKit layers. Manual benchmark runs use a unique image tag and
+never replace the immutable release input.
 
-The image build is unsuitable for a standard GitHub-hosted runner because the
-two Jetson rootfs trees, signed flash package, raw images, voice build, and
+The complete image build remains unsuitable for a standard GitHub-hosted runner
+because the two Jetson rootfs trees, signed flash package, raw images, and
 compressed outputs exceed its disk allowance.
 
 ## Triggers

--- a/infra/appliance/release/README.md
+++ b/infra/appliance/release/README.md
@@ -84,8 +84,9 @@ used only on the build runner; the installed appliance runs native services.
 pinned Dockerfile inputs change. Appliance releases invoke that workflow first
 and consume the exact returned image digest. The isolated voice build runs
 natively on GitHub's `ubuntu-24.04-arm` runner and uses the Actions cache for
-completed BuildKit layers. Manual benchmark runs use a unique image tag and
-never replace the immutable release input.
+completed BuildKit layers. The first uncached native build completed in 46
+minutes; the equivalent x86-64 QEMU build was still compiling after three
+hours.
 
 The complete image build remains unsuitable for a standard GitHub-hosted runner
 because the two Jetson rootfs trees, signed flash package, raw images, and

--- a/infra/appliance/release/README.md
+++ b/infra/appliance/release/README.md
@@ -111,5 +111,5 @@ act -l -W .github/workflows/appliance-release.yml
 ```
 
 The complete image build still requires the dedicated Linux runner and roughly
-200 GiB of scratch space. The GitHub-hosted voice job and self-hosted packaging
-job each allow up to 12 hours.
+200 GiB of scratch space. The GitHub-hosted voice job allows up to six hours;
+the self-hosted packaging job allows up to 12 hours.

--- a/infra/appliance/release/test_build_release_assets.sh
+++ b/infra/appliance/release/test_build_release_assets.sh
@@ -44,7 +44,18 @@ grep -q 'target: appliance-voice-assets' \
     "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0' \
     "$workflow_dir/jetson-voice-assets.yml"
-grep -q 'keep-state: true' \
+grep -q 'runs-on: ubuntu-24.04-arm' \
+    "$workflow_dir/jetson-voice-assets.yml"
+if grep -q 'docker/setup-qemu-action' \
+    "$workflow_dir/jetson-voice-assets.yml"; then
+    echo "Native ARM64 workflow still enables QEMU" >&2
+    exit 1
+fi
+grep -q 'benchmark-${GITHUB_RUN_ID}' \
+    "$workflow_dir/jetson-voice-assets.yml"
+grep -q 'cache-from: type=gha,scope=jetson-voice-assets' \
+    "$workflow_dir/jetson-voice-assets.yml"
+grep -q 'cache-to: type=gha,scope=jetson-voice-assets,mode=max' \
     "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'timeout-minutes: 720' \
     "$workflow_dir/jetson-voice-assets.yml"

--- a/infra/appliance/release/test_build_release_assets.sh
+++ b/infra/appliance/release/test_build_release_assets.sh
@@ -63,7 +63,7 @@ grep -q 'cache-from: type=gha,scope=jetson-voice-assets' \
     "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'cache-to: type=gha,scope=jetson-voice-assets,mode=max' \
     "$workflow_dir/jetson-voice-assets.yml"
-grep -q 'timeout-minutes: 720' \
+grep -q 'timeout-minutes: 360' \
     "$workflow_dir/jetson-voice-assets.yml"
 grep -q '^  validate-release-tag:' \
     "$workflow_dir/appliance-release.yml"
@@ -72,6 +72,8 @@ grep -q 'needs: validate-release-tag' \
 grep -q 'needs: \[validate-release-tag, voice-assets\]' \
     "$workflow_dir/appliance-release.yml"
 grep -Fq 'runs-on: [self-hosted, Linux, X64, jetson-image-builder]' \
+    "$workflow_dir/appliance-release.yml"
+grep -q 'timeout-minutes: 720' \
     "$workflow_dir/appliance-release.yml"
 grep -q 'ref:.*inputs.tag.*github.ref' \
     "$workflow_dir/appliance-release.yml"

--- a/infra/appliance/release/test_build_release_assets.sh
+++ b/infra/appliance/release/test_build_release_assets.sh
@@ -71,7 +71,7 @@ grep -q 'needs: validate-release-tag' \
     "$workflow_dir/appliance-release.yml"
 grep -q 'needs: \[validate-release-tag, voice-assets\]' \
     "$workflow_dir/appliance-release.yml"
-grep -q 'runs-on: \[self-hosted, Linux, X64, jetson-image-builder\]' \
+grep -Fq 'runs-on: [self-hosted, Linux, X64, jetson-image-builder]' \
     "$workflow_dir/appliance-release.yml"
 grep -q 'ref:.*inputs.tag.*github.ref' \
     "$workflow_dir/appliance-release.yml"

--- a/infra/appliance/release/test_build_release_assets.sh
+++ b/infra/appliance/release/test_build_release_assets.sh
@@ -51,7 +51,13 @@ if grep -q 'docker/setup-qemu-action' \
     echo "Native ARM64 workflow still enables QEMU" >&2
     exit 1
 fi
-grep -q 'benchmark-${GITHUB_RUN_ID}' \
+if grep -q 'benchmark' "$workflow_dir/jetson-voice-assets.yml"; then
+    echo "Production voice workflow still contains benchmark-only behavior" >&2
+    exit 1
+fi
+grep -q '^  group: jetson-voice-assets$' \
+    "$workflow_dir/jetson-voice-assets.yml"
+grep -q 'ref=$VOICE_ASSET_IMAGE:sha-$hash' \
     "$workflow_dir/jetson-voice-assets.yml"
 grep -q 'cache-from: type=gha,scope=jetson-voice-assets' \
     "$workflow_dir/jetson-voice-assets.yml"
@@ -64,6 +70,8 @@ grep -q '^  validate-release-tag:' \
 grep -q 'needs: validate-release-tag' \
     "$workflow_dir/appliance-release.yml"
 grep -q 'needs: \[validate-release-tag, voice-assets\]' \
+    "$workflow_dir/appliance-release.yml"
+grep -q 'runs-on: \[self-hosted, Linux, X64, jetson-image-builder\]' \
     "$workflow_dir/appliance-release.yml"
 grep -q 'ref:.*inputs.tag.*github.ref' \
     "$workflow_dir/appliance-release.yml"

--- a/infra/docker/Dockerfile.agenthost-jetson-voice
+++ b/infra/docker/Dockerfile.agenthost-jetson-voice
@@ -3,7 +3,7 @@
 # Target device : NVIDIA Jetson Orin Nano Super 8GB — L4T R36.4.7 / JetPack 6.2
 #                 CUDA 12.6 (host 12.6.11), cuDNN 9, Ampere GA10B (compute 8.7 / sm_87)
 # Target image  : linux/arm64
-# Build host    : x86_64 desktop (BuildX + QEMU for the arm64 native stages)
+# Build host    : native ARM64 Linux; x86_64 Buildx + QEMU remains compatible
 #
 # Why one Dockerfile (was two + a docker-image:// named context):
 #   The prior split used `--build-context native-assets=docker-image://...`, which


### PR DESCRIPTION
## Description

The appliance release spent hours compiling ARM64 ONNX Runtime and sherpa-onnx under QEMU before local packaging could begin. A production-shaped benchmark completed the same voice asset build on GitHub's native ARM64 runner in 46 minutes while the x86/QEMU build was still compiling after three hours.

This change makes that measured path permanent. GitHub ARM64 builds and publishes the content-addressed voice dependency image first; the dedicated local runner waits for its immutable digest, then handles the large Jetson rootfs, packaging, and release assets.

## Type of Change
Please select the relevant options:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Style/formatting changes
- [ ] ♻️ Code refactoring (no functional changes)
- [x] ⚡ Performance improvements
- [x] ✅ Test updates
- [x] 🔧 Build/CI changes

## Related Issues
N/A

## Changes Made
- [x] Run the isolated voice dependency build on `ubuntu-24.04-arm` without QEMU.
- [x] Cache completed BuildKit layers through the GitHub Actions cache.
- [x] Keep content-hash lookup, immutable GHCR publishing, and exact digest handoff to appliance packaging.
- [x] Keep rootfs assembly, image creation, and release packaging on the dedicated self-hosted runner.
- [x] Remove benchmark-only tags and force behavior from the production workflow.

## Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

### Test Environment
- **OS:** GitHub `ubuntu-24.04-arm` and Windows 11
- **Browser:** N/A
- **Node version:** N/A

## Screenshots/Demo
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes
The native ARM64 benchmark completed in 46 minutes. The equivalent x86/QEMU release build was cancelled after more than three hours while still compiling.

## Breaking Changes
N/A

## Migration Guide
N/A

---

**For Reviewers:**
- [ ] Code quality and style
- [ ] Functionality works as expected
- [ ] Tests are comprehensive
- [ ] Documentation is updated
- [ ] No security concerns
- [ ] Performance impact is acceptable